### PR TITLE
Add core HTTP client protocol layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,46 @@ The `ssl` option is required because this library depends on the `ssl` package v
 
 Package: `courier` (repo name is `courier`, Pony package name is `courier`)
 
+## Architecture
+
+### Layer: Core Protocol (PR 1)
+
+Courier follows the same pattern as lori and stallion: protocol handler class owned by the user's actor, with synchronous `fun ref` callbacks.
+
+**Connection layer:**
+- `HTTPClientConnection` — protocol handler class, implements `lori.ClientLifecycleEventReceiver` and `_ResponseParserNotify`. Stored as a field in the user's actor.
+- `HTTPClientConnectionActor` — trait the user's actor implements (`lori.TCPConnectionActor & HTTPClientLifecycleEventReceiver`)
+- `HTTPClientLifecycleEventReceiver` — callback trait with default no-ops: `on_connected`, `on_connection_failure`, `on_response`, `on_body_chunk`, `on_response_complete`, `on_parse_error`, `on_closed`, `on_throttled`, `on_unthrottled`
+- `ClientConnectionConfig` — parser size limits, idle timeout, local bind address
+- `_ConnectionState` — two-state trait (`_Active`/`_Closed`) routing lori events
+
+**Request/Response types:**
+- `HTTPRequest` — `class val` with method, path, headers, optional body
+- `Response` — `class val` with version, status, reason, headers (delivered via `on_response()`)
+- `SendRequestResult` — `(SendRequestOK | ConnectionClosed | ResponsePending)`
+- `Method` — interface + 9 primitives (GET through PATCH) + `Methods` parser
+- `Headers` — case-insensitive header collection (set/add/get/size/values)
+- `Version` — `HTTP10 | HTTP11`
+- `ParseError` — union of error primitives (TooLarge, InvalidStatusLine, etc.)
+
+**Response parser (internal):**
+- `_ResponseParser` — class, feeds data in chunks, delivers via `_ResponseParserNotify`
+- `_ParserState` — trait-based state machine: `_ExpectStatusLine`, `_ExpectHeaders`, `_ExpectFixedBody`, `_ExpectChunkHeader`, `_ExpectChunkData`, `_ExpectChunkTrailer`, `_ExpectCloseDelimitedBody`
+- 1xx informational responses are silently discarded
+- HEAD, 204, 304 responses have no body regardless of headers
+- Close-delimited body: no CL/chunked → body ends when connection closes (`connection_closed()`)
+
+**Request serializer (internal):**
+- `_RequestSerializer` — auto-sets Host and Content-Length if not present
+
+### Key Design Decisions
+
+- `send_request()` returns explicit `SendRequestResult`, not fire-and-forget
+- Only one request in flight at a time (`_Idle`/`_AwaitingResponse` state)
+- User-initiated close does NOT complete in-progress close-delimited responses
+- Remote close DOES complete close-delimited responses (natural end signal)
+- `_on_tls_ready`/`_on_tls_failure` inherited as no-ops — lori routes initial SSL through `_on_connected`/`_on_connection_failure`
+
 ## Release Notes
 
 Follow the standard ponylang release notes conventions. Create individual `.md` files in `.release-notes/` for each PR with user-facing changes.

--- a/courier/_connection_state.pony
+++ b/courier/_connection_state.pony
@@ -1,0 +1,64 @@
+trait ref _ConnectionState
+  """
+  Connection lifecycle state.
+
+  Dispatches lori events to the appropriate client methods based on
+  what operations are valid in each state. Two states: `_Active`
+  (connection is open for requests and responses) and `_Closed`
+  (all operations are no-ops).
+  """
+
+  fun ref on_received(client: HTTPClientConnection ref, data: Array[U8] iso)
+    """Handle incoming data from the TCP connection."""
+
+  fun ref on_closed(client: HTTPClientConnection ref)
+    """Handle connection close notification."""
+
+  fun ref on_throttled(client: HTTPClientConnection ref)
+    """Handle backpressure applied notification."""
+
+  fun ref on_unthrottled(client: HTTPClientConnection ref)
+    """Handle backpressure released notification."""
+
+  fun ref on_idle_timeout(client: HTTPClientConnection ref)
+    """Handle connection going idle."""
+
+class ref _Active is _ConnectionState
+  """
+  Connection is active — sending requests and receiving responses.
+  """
+
+  fun ref on_received(client: HTTPClientConnection ref, data: Array[U8] iso) =>
+    client._feed_parser(consume data)
+
+  fun ref on_closed(client: HTTPClientConnection ref) =>
+    client._handle_closed()
+
+  fun ref on_throttled(client: HTTPClientConnection ref) =>
+    client._handle_throttled()
+
+  fun ref on_unthrottled(client: HTTPClientConnection ref) =>
+    client._handle_unthrottled()
+
+  fun ref on_idle_timeout(client: HTTPClientConnection ref) =>
+    client._handle_idle_timeout()
+
+class ref _Closed is _ConnectionState
+  """
+  Connection is closed — all operations are no-ops.
+  """
+
+  fun ref on_received(client: HTTPClientConnection ref, data: Array[U8] iso) =>
+    None
+
+  fun ref on_closed(client: HTTPClientConnection ref) =>
+    None
+
+  fun ref on_throttled(client: HTTPClientConnection ref) =>
+    None
+
+  fun ref on_unthrottled(client: HTTPClientConnection ref) =>
+    None
+
+  fun ref on_idle_timeout(client: HTTPClientConnection ref) =>
+    None

--- a/courier/_mort.pony
+++ b/courier/_mort.pony
@@ -1,0 +1,35 @@
+use @exit[None](status: I32)
+use @fprintf[I32](stream: Pointer[None] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[None]]()
+
+primitive _IllegalState
+  """
+  To be used to exit early if we called a function that shouldn't be possible
+  in our current state.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("An illegal state was encountered in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/courier/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/courier/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/courier/_parser_config.pony
+++ b/courier/_parser_config.pony
@@ -1,0 +1,21 @@
+class val _ParserConfig
+  """
+  Configuration for HTTP response parser size limits.
+
+  All limits are in bytes. Responses exceeding any limit produce a parse error.
+  """
+  let max_status_line_size: USize
+  let max_header_size: USize
+  let max_chunk_header_size: USize
+  let max_body_size: USize
+
+  new val create(
+    max_status_line_size': USize = 8192,
+    max_header_size': USize = 8192,
+    max_chunk_header_size': USize = 128,
+    max_body_size': USize = 10_485_760)
+  =>
+    max_status_line_size = max_status_line_size'
+    max_header_size = max_header_size'
+    max_chunk_header_size = max_chunk_header_size'
+    max_body_size = max_body_size'

--- a/courier/_parser_state.pony
+++ b/courier/_parser_state.pony
@@ -1,0 +1,615 @@
+primitive _ParseContinue
+  """More data may be parseable in the current buffer."""
+
+primitive _ParseNeedMore
+  """Need more data from the network before parsing can continue."""
+
+type _ParseResult is (_ParseContinue | _ParseNeedMore | ParseError)
+  """Result of a single parse step."""
+
+interface ref _ParserState
+  """
+  A state in the HTTP response parser state machine.
+
+  Each state is a class that owns its per-state data (buffers,
+  accumulators). State transitions are explicit assignments to
+  `p.state`. Per-state data is automatically cleaned up when
+  the state transitions out.
+  """
+  fun ref parse(p: _ResponseParser ref): _ParseResult
+
+// ---------------------------------------------------------------------------
+// Buffer scanning utilities
+// ---------------------------------------------------------------------------
+
+primitive _BufferScan
+  """Byte-level scanning utilities for the parser buffer."""
+
+  fun find_crlf(buf: Array[U8] box, from: USize = 0): (USize | None) =>
+    """
+    Find the position of \\r\\n in buf starting from `from`.
+    Returns the index of \\r, or None if not found.
+    """
+    if buf.size() < (from + 2) then return None end
+    var i = from
+    let limit = buf.size() - 1
+    try
+      while i < limit do
+        if (buf(i)? == '\r') and (buf(i + 1)? == '\n') then
+          return i
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    None
+
+  fun find_byte(
+    buf: Array[U8] box,
+    byte: U8,
+    from: USize,
+    to: USize = USize.max_value())
+    : (USize | None)
+  =>
+    """Find the first occurrence of `byte` in buf[from, to)."""
+    var i = from
+    let limit = to.min(buf.size())
+    try
+      while i < limit do
+        if buf(i)? == byte then return i end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    None
+
+// ---------------------------------------------------------------------------
+// Parser states
+// ---------------------------------------------------------------------------
+
+class _ExpectStatusLine is _ParserState
+  """
+  Waiting for a complete HTTP status line.
+
+  Format: HTTP-version SP status-code SP reason-phrase CRLF
+  """
+  let _config: _ParserConfig
+
+  new create(config: _ParserConfig) =>
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    let available = p.buf.size() - p.pos
+
+    match _BufferScan.find_crlf(p.buf, p.pos)
+    | let crlf: USize =>
+      let line_len = crlf - p.pos
+      if line_len > _config.max_status_line_size then
+        return TooLarge
+      end
+
+      // Parse version: must start with "HTTP/1.0" or "HTTP/1.1"
+      if line_len < 12 then
+        // Minimum: "HTTP/1.x NNN" = 12 chars
+        return InvalidStatusLine
+      end
+
+      let version = try
+        if (p.buf(p.pos)? == 'H')
+          and (p.buf(p.pos + 1)? == 'T')
+          and (p.buf(p.pos + 2)? == 'T')
+          and (p.buf(p.pos + 3)? == 'P')
+          and (p.buf(p.pos + 4)? == '/')
+          and (p.buf(p.pos + 5)? == '1')
+          and (p.buf(p.pos + 6)? == '.')
+        then
+          let minor = p.buf(p.pos + 7)?
+          if minor == '1' then
+            HTTP11
+          elseif minor == '0' then
+            HTTP10
+          else
+            return InvalidVersion
+          end
+        else
+          return InvalidVersion
+        end
+      else
+        _Unreachable()
+        return InvalidVersion
+      end
+
+      // Expect space after version
+      try
+        if p.buf(p.pos + 8)? != ' ' then
+          return InvalidStatusLine
+        end
+      else
+        _Unreachable()
+        return InvalidStatusLine
+      end
+
+      // Parse 3-digit status code at pos+9
+      let status_start = p.pos + 9
+      if (status_start + 3) > crlf then
+        return InvalidStatusLine
+      end
+
+      let status: U16 = try
+        let d1 = p.buf(status_start)?
+        let d2 = p.buf(status_start + 1)?
+        let d3 = p.buf(status_start + 2)?
+        if (d1 < '0') or (d1 > '9')
+          or (d2 < '0') or (d2 > '9')
+          or (d3 < '0') or (d3 > '9')
+        then
+          return InvalidStatusLine
+        end
+        (((d1 - '0').u16() * 100) +
+         ((d2 - '0').u16() * 10) +
+          (d3 - '0').u16())
+      else
+        _Unreachable()
+        return InvalidStatusLine
+      end
+
+      // Reason phrase: everything after status code to CRLF
+      // May be empty. If present, a space separates status from reason.
+      let after_status = status_start + 3
+      let reason: String val = if after_status < crlf then
+        // Skip the space between status and reason
+        let reason_start = if try
+          p.buf(after_status)? == ' '
+        else
+          _Unreachable()
+          false
+        end then
+          after_status + 1
+        else
+          after_status
+        end
+        p.extract_string(reason_start, crlf)
+      else
+        ""
+      end
+
+      // Advance past the status line
+      p.pos = crlf + 2
+
+      // Transition to header parsing
+      p.state = _ExpectHeaders(status, reason, version, _config)
+      _ParseContinue
+
+    | None =>
+      // No complete line yet — check size limit
+      if available > _config.max_status_line_size then
+        TooLarge
+      else
+        _ParseNeedMore
+      end
+    end
+
+class _ExpectHeaders is _ParserState
+  """
+  Parsing HTTP headers after the status line.
+
+  Loops through header lines until an empty line (CRLF) marks the end
+  of headers. Tracks Content-Length and Transfer-Encoding for body handling.
+  Determines body framing per RFC 7230 §3.3.3 for responses.
+  """
+  let _status: U16
+  let _reason: String val
+  let _version: Version
+  let _config: _ParserConfig
+  var _headers: Headers iso = recover iso Headers end
+  var _content_length: (USize | None) = None
+  var _chunked: Bool = false
+  var _total_header_bytes: USize = 0
+
+  new create(
+    status: U16,
+    reason: String val,
+    version: Version,
+    config: _ParserConfig)
+  =>
+    _status = status
+    _reason = reason
+    _version = version
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    while true do
+      match _BufferScan.find_crlf(p.buf, p.pos)
+      | let crlf: USize =>
+        if crlf == p.pos then
+          // Empty line: end of headers
+          p.pos = crlf + 2
+
+          // 1xx informational: discard and await the final response
+          if (_status >= 100) and (_status < 200) then
+            p.state = _ExpectStatusLine(_config)
+            return _ParseContinue
+          end
+
+          // Deliver the response metadata
+          let headers: Headers val =
+            (_headers = recover iso Headers end)
+          p.handler.response_received(_status, _reason, _version, headers)
+
+          // Body determination per RFC 7230 §3.3.3:
+          // HEAD responses and 204/304 have no body regardless of headers
+          if (p.method is HEAD) or (_status == 204) or (_status == 304) then
+            p.handler.response_complete()
+            p.state = _ExpectStatusLine(_config)
+            return _ParseContinue
+          end
+
+          // Transfer-Encoding: chunked takes precedence over Content-Length
+          if _chunked then
+            p.state = _ExpectChunkHeader(0, _config)
+            return _ParseContinue
+          end
+
+          match _content_length
+          | let cl: USize if cl > 0 =>
+            // Check body size limit before entering body state
+            if cl > _config.max_body_size then
+              return BodyTooLarge
+            end
+            p.state = _ExpectFixedBody(cl)
+            return _ParseContinue
+          | let _: USize =>
+            // Content-Length: 0
+            p.handler.response_complete()
+            p.state = _ExpectStatusLine(_config)
+            return _ParseContinue
+          else
+            // No Content-Length, no chunked: close-delimited body
+            p.state = _ExpectCloseDelimitedBody(_config)
+            return _ParseContinue
+          end
+        end
+
+        // Track header size
+        let line_len = (crlf - p.pos) + 2
+        _total_header_bytes = _total_header_bytes + line_len
+        if _total_header_bytes > _config.max_header_size then
+          return TooLarge
+        end
+
+        // Check for obs-fold (continuation line): reject per RFC 7230
+        try
+          let first_byte = p.buf(p.pos)?
+          if (first_byte == ' ') or (first_byte == '\t') then
+            return MalformedHeaders
+          end
+        else
+          _Unreachable()
+        end
+
+        // Find colon separator
+        let colon_pos = match _BufferScan.find_byte(p.buf, ':', p.pos, crlf)
+          | let i: USize => i
+          | None => return MalformedHeaders
+          end
+
+        // Header name must not be empty
+        if colon_pos == p.pos then
+          return MalformedHeaders
+        end
+
+        // Extract header name (lowercasing happens in Headers.add)
+        let name: String val = p.extract_string(p.pos, colon_pos)
+
+        // Extract header value, skipping optional whitespace (OWS)
+        var val_start = colon_pos + 1
+        try
+          while val_start < crlf do
+            let ch = p.buf(val_start)?
+            if (ch != ' ') and (ch != '\t') then break end
+            val_start = val_start + 1
+          end
+        else
+          _Unreachable()
+        end
+
+        // Trim trailing OWS from value
+        var val_end = crlf
+        try
+          while val_end > val_start do
+            let ch = p.buf(val_end - 1)?
+            if (ch != ' ') and (ch != '\t') then break end
+            val_end = val_end - 1
+          end
+        else
+          _Unreachable()
+        end
+
+        let value: String val = p.extract_string(val_start, val_end)
+
+        // Detect special headers
+        let lower_name: String val = name.lower()
+        if lower_name == "content-length" then
+          match _parse_content_length(value)
+          | let cl: USize =>
+            match _content_length
+            | let existing: USize =>
+              if existing != cl then
+                return InvalidContentLength
+              end
+            | None =>
+              _content_length = cl
+            end
+          | InvalidContentLength => return InvalidContentLength
+          end
+        elseif lower_name == "transfer-encoding" then
+          if value.lower().contains("chunked") then
+            _chunked = true
+          end
+        end
+
+        _headers.add(name, value)
+
+        // Advance past this header line
+        p.pos = crlf + 2
+      | None =>
+        // No complete line yet — check size limit
+        let pending = p.buf.size() - p.pos
+        if (pending + _total_header_bytes) > _config.max_header_size then
+          return TooLarge
+        end
+        return _ParseNeedMore
+      end
+    end
+    _Unreachable()
+    _ParseNeedMore
+
+  fun _parse_content_length(value: String val)
+    : (USize | InvalidContentLength)
+  =>
+    """Parse a Content-Length value as a non-negative integer."""
+    if value.size() == 0 then
+      return InvalidContentLength
+    end
+    try
+      var i: USize = 0
+      while i < value.size() do
+        let ch = value(i)?
+        if (ch < '0') or (ch > '9') then
+          return InvalidContentLength
+        end
+        i = i + 1
+      end
+      value.read_int[USize]()?._1
+    else
+      InvalidContentLength
+    end
+
+class _ExpectFixedBody is _ParserState
+  """
+  Reading a fixed-length response body (Content-Length).
+
+  Delivers body data incrementally as it becomes available in the buffer.
+  """
+  var _remaining: USize
+
+  new create(remaining: USize) =>
+    _remaining = remaining
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    let available = (p.buf.size() - p.pos).min(_remaining)
+    if available > 0 then
+      let chunk: Array[U8] val =
+        p.extract_bytes(p.pos, p.pos + available)
+      p.handler.body_chunk(chunk)
+      p.pos = p.pos + available
+      _remaining = _remaining - available
+    end
+
+    if _remaining == 0 then
+      p.handler.response_complete()
+      p.state = _ExpectStatusLine(p.config)
+      _ParseContinue
+    else
+      _ParseNeedMore
+    end
+
+class _ExpectChunkHeader is _ParserState
+  """
+  Expecting a chunk size line in chunked transfer encoding.
+
+  Format: chunk-size [ chunk-ext ] CRLF
+  """
+  var _total_body_received: USize
+  let _config: _ParserConfig
+
+  new create(total_body_received: USize, config: _ParserConfig) =>
+    _total_body_received = total_body_received
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    match _BufferScan.find_crlf(p.buf, p.pos)
+    | let crlf: USize =>
+      let line_len = crlf - p.pos
+      if line_len > _config.max_chunk_header_size then
+        return InvalidChunk
+      end
+      if line_len == 0 then
+        return InvalidChunk
+      end
+
+      // Find optional chunk extension (semicolon)
+      let size_end = match _BufferScan.find_byte(p.buf, ';', p.pos, crlf)
+        | let i: USize => i
+        | None => crlf
+        end
+
+      // Parse hex chunk size — must consume entire string
+      let size_str: String val = p.extract_string(p.pos, size_end)
+      let chunk_size = try
+        (let cs, let consumed) = size_str.read_int[USize](0, 16)?
+        if consumed.usize() != size_str.size() then
+          return InvalidChunk
+        end
+        cs
+      else
+        return InvalidChunk
+      end
+
+      p.pos = crlf + 2
+
+      if chunk_size == 0 then
+        // Last chunk — expect trailers or final CRLF
+        p.state = _ExpectChunkTrailer(0, _config)
+        _ParseContinue
+      else
+        // Check body size limit
+        if (_total_body_received + chunk_size) > _config.max_body_size then
+          return BodyTooLarge
+        end
+        p.state = _ExpectChunkData(
+          chunk_size, _total_body_received, _config)
+        _ParseContinue
+      end
+    | None =>
+      // No complete line — check size limit
+      let pending = p.buf.size() - p.pos
+      if pending > _config.max_chunk_header_size then
+        InvalidChunk
+      else
+        _ParseNeedMore
+      end
+    end
+
+class _ExpectChunkData is _ParserState
+  """
+  Reading chunk data in chunked transfer encoding.
+
+  Delivers data incrementally, then expects CRLF after the chunk data.
+  """
+  var _remaining: USize
+  var _total_body_received: USize
+  let _config: _ParserConfig
+
+  new create(
+    remaining: USize,
+    total_body_received: USize,
+    config: _ParserConfig)
+  =>
+    _remaining = remaining
+    _total_body_received = total_body_received
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    if _remaining > 0 then
+      let available = (p.buf.size() - p.pos).min(_remaining)
+      if available > 0 then
+        let chunk: Array[U8] val =
+          p.extract_bytes(p.pos, p.pos + available)
+        p.handler.body_chunk(chunk)
+        p.pos = p.pos + available
+        _remaining = _remaining - available
+        _total_body_received = _total_body_received + available
+      end
+      if _remaining > 0 then
+        return _ParseNeedMore
+      end
+    end
+
+    // Chunk data consumed — expect CRLF
+    let bytes_available = p.buf.size() - p.pos
+    if bytes_available < 2 then
+      return _ParseNeedMore
+    end
+
+    try
+      if (p.buf(p.pos)? == '\r') and (p.buf(p.pos + 1)? == '\n') then
+        p.pos = p.pos + 2
+        p.state = _ExpectChunkHeader(_total_body_received, _config)
+        _ParseContinue
+      else
+        InvalidChunk
+      end
+    else
+      _Unreachable()
+      InvalidChunk
+    end
+
+class _ExpectChunkTrailer is _ParserState
+  """
+  Reading optional trailer headers after the last (zero-size) chunk.
+
+  Trailers are skipped (not delivered to the receiver). The response is
+  complete when an empty line is found.
+  """
+  var _total_trailer_bytes: USize
+  let _config: _ParserConfig
+
+  new create(total_trailer_bytes: USize, config: _ParserConfig) =>
+    _total_trailer_bytes = total_trailer_bytes
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    while true do
+      match _BufferScan.find_crlf(p.buf, p.pos)
+      | let crlf: USize =>
+        if crlf == p.pos then
+          // Empty line: end of chunked message
+          p.pos = crlf + 2
+          p.handler.response_complete()
+          p.state = _ExpectStatusLine(p.config)
+          return _ParseContinue
+        end
+
+        // Skip this trailer header line
+        let line_len = (crlf - p.pos) + 2
+        _total_trailer_bytes = _total_trailer_bytes + line_len
+        if _total_trailer_bytes > _config.max_header_size then
+          return TooLarge
+        end
+
+        p.pos = crlf + 2
+      | None =>
+        let pending = p.buf.size() - p.pos
+        if (pending + _total_trailer_bytes) > _config.max_header_size then
+          return TooLarge
+        end
+        return _ParseNeedMore
+      end
+    end
+    _Unreachable()
+    _ParseNeedMore
+
+class _ExpectCloseDelimitedBody is _ParserState
+  """
+  Reading a response body delimited by connection close.
+
+  Used when the response has neither Content-Length nor Transfer-Encoding:
+  chunked. Delivers all available data via `body_chunk()` and tracks total
+  bytes received. Returns `_ParseNeedMore` to request more data. Completion
+  is triggered externally by `_ResponseParser.connection_closed()`, not by
+  `parse()`.
+  """
+  let _config: _ParserConfig
+  var _total_received: USize = 0
+
+  new create(config: _ParserConfig) =>
+    _config = config
+
+  fun ref parse(p: _ResponseParser ref): _ParseResult =>
+    let available = p.buf.size() - p.pos
+    if available > 0 then
+      let chunk: Array[U8] val =
+        p.extract_bytes(p.pos, p.pos + available)
+      p.pos = p.pos + available
+      _total_received = _total_received + available
+
+      if _total_received > _config.max_body_size then
+        return BodyTooLarge
+      end
+
+      p.handler.body_chunk(chunk)
+    end
+    _ParseNeedMore

--- a/courier/_request_serializer.pony
+++ b/courier/_request_serializer.pony
@@ -1,0 +1,64 @@
+primitive _RequestSerializer
+  """
+  Serialize an `HTTPRequest` into HTTP/1.1 wire format.
+
+  Produces: `METHOD SP PATH SP HTTP/1.1\r\n` + headers + `\r\n` + body.
+
+  Auto-sets `Host` from the connection's host/port if not already present.
+  Port is omitted for "80" and "443" (standard ports); included otherwise.
+  Auto-sets `Content-Length` from body size if body is present and not already
+  in the request headers. User-explicit headers take precedence.
+  """
+
+  fun apply(
+    request: HTTPRequest val,
+    host: String,
+    port: String)
+    : Array[U8] iso^
+  =>
+    let buf = recover iso Array[U8] end
+
+    // Request line: METHOD SP PATH SP HTTP/1.1\r\n
+    buf.>append(request.method.string())
+      .>push(' ')
+      .>append(request.path)
+      .>append(" HTTP/1.1\r\n")
+
+    // Host header (auto-set if not present)
+    if request.headers.get("host") is None then
+      buf.append("Host: ")
+      buf.append(host)
+      if (port != "80") and (port != "443") and (port != "") then
+        buf.>push(':')
+          .>append(port)
+      end
+      buf.append("\r\n")
+    end
+
+    // Content-Length header (auto-set if body present and not already set)
+    match request.body
+    | let b: Array[U8] val =>
+      if request.headers.get("content-length") is None then
+        buf.>append("Content-Length: ")
+          .>append(b.size().string())
+          .>append("\r\n")
+      end
+    end
+
+    // User headers
+    for (name, value) in request.headers.values() do
+      buf.>append(name)
+        .>append(": ")
+        .>append(value)
+        .>append("\r\n")
+    end
+
+    // End of headers
+    buf.append("\r\n")
+
+    // Body
+    match request.body
+    | let b: Array[U8] val => buf.append(b)
+    end
+
+    buf

--- a/courier/_response_parser.pony
+++ b/courier/_response_parser.pony
@@ -1,0 +1,121 @@
+class _ResponseParser
+  """
+  HTTP/1.1 response parser.
+
+  Data is fed in as chunks via `parse()` (matching lori's delivery model).
+  Parsed responses are delivered via the `_ResponseParserNotify` callback
+  interface. The parser handles arbitrary chunk boundaries, connection reuse
+  (multiple responses on the same connection), and both fixed-length, chunked,
+  and close-delimited transfer encoding.
+
+  The `method` field stores the request method for the response currently
+  being parsed. HEAD responses and 204/304 responses have no body regardless
+  of headers — the method is needed to detect HEAD.
+
+  Fields are public so that state classes (in the same package) can access
+  them for buffer reading, position tracking, state transitions, and handler
+  callbacks.
+  """
+  var state: _ParserState
+  let handler: _ResponseParserNotify ref
+  let config: _ParserConfig
+  var buf: Array[U8] ref = Array[U8]
+  var pos: USize = 0
+  var method: Method = GET
+  var _failed: Bool = false
+
+  new create(
+    handler': _ResponseParserNotify ref,
+    config': _ParserConfig = _ParserConfig)
+  =>
+    handler = handler'
+    config = config'
+    state = _ExpectStatusLine(config)
+
+  fun ref expect_response(method': Method) =>
+    """
+    Prepare the parser to receive a response for the given request method.
+
+    Sets the method (needed for HEAD body suppression) and resets state to
+    `_ExpectStatusLine`. Called by `HTTPClientConnection.send_request()`.
+    """
+    method = method'
+    state = _ExpectStatusLine(config)
+
+  fun ref parse(data: Array[U8] iso) =>
+    """
+    Feed data to the parser.
+
+    The parser processes as much data as possible in a single call,
+    delivering callbacks for each complete response (or response component)
+    found. Remaining partial data is buffered for the next call.
+    """
+    if _failed then return end
+
+    buf.append(consume data)
+
+    var continue_parsing = true
+    while continue_parsing do
+      match state.parse(this)
+      | _ParseContinue =>
+        if _failed then break end
+      | _ParseNeedMore => continue_parsing = false
+      | let err: ParseError =>
+        handler.parse_error(err)
+        _failed = true
+        continue_parsing = false
+      end
+    end
+
+    // Compact consumed data
+    if pos > 0 then
+      buf.trim_in_place(pos)
+      pos = 0
+    end
+
+  fun ref connection_closed() =>
+    """
+    Signal that the remote end closed the connection.
+
+    If the parser is currently in `_ExpectCloseDelimitedBody` state, this
+    completes the response by calling `handler.response_complete()`. For
+    all other states, this is a no-op — the connection class handles
+    `on_closed()` separately.
+    """
+    if _failed then return end
+    match state
+    | let _: _ExpectCloseDelimitedBody =>
+      handler.response_complete()
+      _failed = true
+    end
+
+  fun ref stop() =>
+    """
+    Stop the parser. All subsequent `parse()` calls become no-ops.
+
+    Safe to call from within a handler callback during parsing — the parse
+    loop checks the failed flag after each state transition.
+    """
+    _failed = true
+
+  fun ref extract_bytes(from: USize, to: USize): Array[U8] iso^ =>
+    """Copy bytes from buf[from..to) into a new iso array."""
+    let len = to - from
+    let out = recover Array[U8].create(len) end
+    var i = from
+    while i < to do
+      try out.push(buf(i)?) else _Unreachable() end
+      i = i + 1
+    end
+    out
+
+  fun ref extract_string(from: USize, to: USize): String iso^ =>
+    """Copy bytes from buf[from..to) into a new iso String."""
+    let len = to - from
+    let out = recover String.create(len) end
+    var i = from
+    while i < to do
+      try out.push(buf(i)?) else _Unreachable() end
+      i = i + 1
+    end
+    out

--- a/courier/_response_parser_notify.pony
+++ b/courier/_response_parser_notify.pony
@@ -1,0 +1,40 @@
+trait ref _ResponseParserNotify
+  """
+  Callback interface for the HTTP response parser.
+  """
+
+  fun ref response_received(
+    status: U16,
+    reason: String val,
+    version: Version,
+    headers: Headers val)
+  """
+  Called when the status line and all headers have been parsed.
+
+  For responses with a body (Content-Length, chunked, or close-delimited),
+  `body_chunk` calls follow. For responses without a body (HEAD, 204, 304),
+  `response_complete` is called immediately after.
+  """
+
+  fun ref body_chunk(data: Array[U8] val)
+  """
+  Called for each chunk of response body data as it becomes available.
+
+  Body data is delivered incrementally — not accumulated.
+  """
+
+  fun ref response_complete()
+  """
+  Called when the entire response (including any body) has been received.
+
+  After this call, the parser is ready to parse the next response on the
+  same connection (keep-alive).
+  """
+
+  fun ref parse_error(err: ParseError)
+  """
+  Called when a parse error is encountered.
+
+  After this call, the parser enters a terminal failed state and will not
+  produce any further callbacks. The connection should be closed.
+  """

--- a/courier/_test.pony
+++ b/courier/_test.pony
@@ -1,4 +1,5 @@
 use "pony_test"
+use "pony_check"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
@@ -8,4 +9,71 @@ actor \nodoc\ Main is TestList
     None
 
   fun tag tests(test: PonyTest) =>
-    None
+    // Method tests
+    test(Property1UnitTest[String val](_PropertyValidMethodParsesCorrectly))
+    test(Property1UnitTest[String val](_PropertyInvalidMethodReturnsNone))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyMethodParseBoundary))
+
+    // Headers tests
+    test(Property1UnitTest[(String val, String val)](
+      _PropertyHeadersCaseInsensitive))
+    test(Property1UnitTest[(String val, String val, String val)](
+      _PropertyHeadersSetReplaces))
+    test(Property1UnitTest[(String val, String val, String val)](
+      _PropertyHeadersAddPreserves))
+
+    // Parser property-based tests
+    test(Property1UnitTest[(U16, String val)](
+      _PropertyValidStatusLineParsesCorrectly))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidStatusLineRejected))
+    test(Property1UnitTest[Array[(String val, String val)] ref](
+      _PropertyHeadersRoundtrip))
+    test(Property1UnitTest[USize](
+      _PropertyFixedBodyDelivered))
+    test(Property1UnitTest[Array[USize] ref](
+      _PropertyChunkedBodyDelivered))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyStatusLineBoundary))
+
+    // Parser example-based tests
+    test(_TestParserKnownGoodResponses)
+    test(_TestIncrementalByteByByte)
+    test(_TestSizeLimitStatusLine)
+    test(_TestSizeLimitHeaders)
+    test(_TestSizeLimitBody)
+    test(_TestSizeLimitCloseDelimitedBody)
+    test(_TestInvalidContentLength)
+    test(_TestInvalidChunkSize)
+    test(_TestChunkedWithTrailers)
+    test(_TestHTTP10Version)
+    test(_TestInvalidVersion)
+    test(_TestNoBodyHead)
+    test(_TestNoBody204)
+    test(_TestNoBody304)
+    test(_TestCloseDelimitedBody)
+    test(_TestContentLengthZero)
+    test(_TestContentLengthAndChunked)
+    test(_TestDuplicateContentLength)
+    test(_TestDataAfterError)
+    test(_Test1xxSkipped)
+    test(_TestMultiple1xx)
+
+    // Serializer property-based tests
+    test(Property1UnitTest[String val](
+      _PropertySerializerContainsMethod))
+    test(Property1UnitTest[String val](
+      _PropertySerializerContainsPath))
+    test(Property1UnitTest[String val](
+      _PropertySerializerAutoHost))
+    test(Property1UnitTest[USize](
+      _PropertySerializerAutoContentLength))
+
+    // Serializer example-based tests
+    test(_TestSerializerKnownGood)
+    test(_TestSerializerHostWithPort)
+    test(_TestSerializerHostDefaultPort)
+    test(_TestSerializerUserHostTakesPrecedence)
+    test(_TestSerializerUserContentLengthTakesPrecedence)
+    test(_TestSerializerNoBody)

--- a/courier/_test_headers.pony
+++ b/courier/_test_headers.pony
@@ -1,0 +1,107 @@
+use "pony_check"
+
+class \nodoc\ iso _PropertyHeadersCaseInsensitive
+  is Property1[(String val, String val)]
+  """
+  Adding a header and retrieving it with a different case variant returns
+  the same value.
+  """
+  fun name(): String => "headers/case_insensitive"
+
+  fun gen(): Generator[(String val, String val)] =>
+    Generators.zip2[String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let value) = arg1
+    let headers = Headers
+    headers.add(header_name, value)
+
+    // Retrieve with different case variants
+    ph.assert_eq[String val](
+      value, _get_or_empty(headers, header_name.upper()))
+    ph.assert_eq[String val](
+      value, _get_or_empty(headers, header_name.lower()))
+
+  fun _get_or_empty(headers: Headers box, header_name: String)
+    : String val
+  =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end
+
+class \nodoc\ iso _PropertyHeadersSetReplaces
+  is Property1[(String val, String val, String val)]
+  """
+  Calling `set()` twice for the same name keeps only the second value.
+  """
+  fun name(): String => "headers/set_replaces"
+
+  fun gen(): Generator[(String val, String val, String val)] =>
+    Generators.zip3[String val, String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let v1, let v2) = arg1
+    let headers = Headers
+    headers.set(header_name, v1)
+    headers.set(header_name, v2)
+
+    ph.assert_eq[USize](1, headers.size())
+    ph.assert_eq[String val](v2, _get_or_empty(headers, header_name))
+
+  fun _get_or_empty(headers: Headers box, header_name: String)
+    : String val
+  =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end
+
+class \nodoc\ iso _PropertyHeadersAddPreserves
+  is Property1[(String val, String val, String val)]
+  """
+  Calling `add()` twice for the same name keeps both values. `get()` returns
+  the first, and `size()` reflects both entries.
+  """
+  fun name(): String => "headers/add_preserves"
+
+  fun gen(): Generator[(String val, String val, String val)] =>
+    Generators.zip3[String val, String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let v1, let v2) = arg1
+    let headers = Headers
+    headers.add(header_name, v1)
+    headers.add(header_name, v2)
+
+    ph.assert_eq[USize](2, headers.size())
+    // get() returns the first value added
+    ph.assert_eq[String val](v1, _get_or_empty(headers, header_name))
+
+  fun _get_or_empty(headers: Headers box, header_name: String)
+    : String val
+  =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end

--- a/courier/_test_method.pony
+++ b/courier/_test_method.pony
@@ -1,0 +1,94 @@
+use "pony_check"
+
+class \nodoc\ iso _PropertyValidMethodParsesCorrectly is Property1[String val]
+  fun name(): String => "method/valid_parse"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["GET"; "HEAD"; "POST"; "PUT"; "DELETE"
+       "CONNECT"; "OPTIONS"; "TRACE"; "PATCH"])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match Methods.parse(arg1)
+    | let m: Method =>
+      ph.assert_eq[String val](arg1, m.string())
+    else
+      ph.fail("valid method string should parse: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyInvalidMethodReturnsNone is Property1[String val]
+  fun name(): String => "method/invalid_returns_none"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // empty string
+      (1, Generators.unit[String val](""))
+      // wrong case
+      (1, Generators.one_of[String val](
+        ["get"; "head"; "post"; "put"; "delete"
+         "connect"; "options"; "trace"; "patch"]))
+      // valid method with extra chars appended
+      (1, Generators.one_of[String val](
+        ["GETX"; "POSTY"; "PUTS"; "DELETES"
+         "HEADS"; "CONNECTX"; "OPTIONS!"; "TRACES"; "PATCHX"]))
+      // truncated valid methods
+      (1, Generators.one_of[String val](
+        ["GE"; "HEA"; "POS"; "PU"; "DELET"
+         "CONNEC"; "OPTION"; "TRAC"; "PATC"]))
+      // numeric strings
+      (1, Generators.ascii_numeric(1, 10))
+      // random ASCII (vanishingly small chance of being a valid method)
+      (2, Generators.ascii(1, 20))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_true(
+      Methods.parse(arg1) is None,
+      "invalid method string should not parse: " + arg1)
+
+class \nodoc\ iso _PropertyMethodParseBoundary
+  is Property1[(String val, Bool)]
+  fun name(): String => "method/parse_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    let valid_gen: Generator[(String val, Bool)] =
+      Generators.one_of[String val](
+        ["GET"; "HEAD"; "POST"; "PUT"; "DELETE"
+         "CONNECT"; "OPTIONS"; "TRACE"; "PATCH"])
+        .map[(String val, Bool)]({(s) => (s, true) })
+
+    let invalid_gen: Generator[(String val, Bool)] =
+      Generators.frequency[String val]([
+        as WeightedGenerator[String val]:
+        (1, Generators.unit[String val](""))
+        (1, Generators.one_of[String val](
+          ["get"; "head"; "post"; "put"; "delete"
+           "connect"; "options"; "trace"; "patch"]))
+        (1, Generators.one_of[String val](
+          ["GETX"; "POSTY"; "PUTS"; "DELETES"]))
+        (1, Generators.ascii_numeric(1, 10))
+        (2, Generators.ascii(1, 20))
+      ]).map[(String val, Bool)]({(s) => (s, false) })
+
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_gen)
+      (1, invalid_gen)
+    ])
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let input, let should_parse) = arg1
+    let result = Methods.parse(input)
+    if should_parse then
+      match result
+      | let m: Method =>
+        ph.assert_eq[String val](input, m.string())
+      else
+        ph.fail("expected parse success for: " + input)
+      end
+    else
+      ph.assert_true(
+        result is None,
+        "expected parse failure for: " + input)
+    end

--- a/courier/_test_parser.pony
+++ b/courier/_test_parser.pony
@@ -1,0 +1,869 @@
+use "format"
+use "pony_check"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Test helper: recording implementation of _ResponseParserNotify
+// ---------------------------------------------------------------------------
+
+class \nodoc\ _TestResponseParserNotify is _ResponseParserNotify
+  embed responses: Array[(U16, String val, Version, Headers val)] =
+    Array[(U16, String val, Version, Headers val)]
+  embed body_chunks: Array[Array[U8] val] = Array[Array[U8] val]
+  var completed: USize = 0
+  embed errors: Array[ParseError] = Array[ParseError]
+
+  fun ref response_received(
+    status: U16,
+    reason: String val,
+    version: Version,
+    headers: Headers val)
+  =>
+    responses.push((status, reason, version, headers))
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    body_chunks.push(data)
+
+  fun ref response_complete() =>
+    completed = completed + 1
+
+  fun ref parse_error(err: ParseError) =>
+    errors.push(err)
+
+  fun ref collected_body_string(): String val =>
+    """Concatenate all body chunks into a single string."""
+    let out = String
+    for chunk in body_chunks.values() do
+      out.append(chunk)
+    end
+    out.clone()
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertyValidStatusLineParsesCorrectly
+  is Property1[(U16, String val)]
+  """
+  Valid (status, reason) pairs serialized as HTTP/1.1 status lines parse
+  correctly, delivering response_received with matching values and then
+  response_complete.
+  """
+  fun name(): String => "parser/valid_status_line"
+
+  fun gen(): Generator[(U16, String val)] =>
+    Generators.zip2[U16, String val](
+      Generators.u16(200, 599),
+      Generators.one_of[String val](
+        ["OK"; "Not Found"; "Internal Server Error"
+         "Created"; "Moved Permanently"; ""]))
+
+  fun ref property(arg1: (U16, String val), ph: PropertyHelper) =>
+    (let status, let reason) = arg1
+    let raw: String val =
+      "HTTP/1.1 " + status.string() + " " + reason +
+      "\r\nContent-Length: 0\r\n\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+    try
+      (let s, let r, let v, _) = notify.responses(0)?
+      ph.assert_eq[U16](status, s, "status mismatch")
+      ph.assert_eq[String val](reason, r, "reason mismatch")
+      ph.assert_true(v is HTTP11, "version should be HTTP/1.1")
+    else
+      ph.fail("could not read response")
+    end
+
+class \nodoc\ iso _PropertyInvalidStatusLineRejected
+  is Property1[String val]
+  """
+  Malformed status lines produce parse errors.
+  """
+  fun name(): String => "parser/invalid_status_line_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // No space after version
+      (1, Generators.unit[String val]("HTTP/1.1200 OK\r\n\r\n"))
+      // Non-numeric status
+      (1, Generators.unit[String val]("HTTP/1.1 abc OK\r\n\r\n"))
+      // Too short
+      (1, Generators.unit[String val]("HTTP/1.1\r\n\r\n"))
+      // Two-digit status
+      (1, Generators.unit[String val]("HTTP/1.1 20 OK\r\n\r\n"))
+      // Random garbage
+      (1, Generators.ascii(5, 30)
+        .map[String val]({(s) => s + "\r\n\r\n" }))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover arg1.array().clone() end)
+
+    ph.assert_eq[USize](0, notify.responses.size(),
+      "should have 0 responses for: " + arg1)
+    ph.assert_eq[USize](1, notify.errors.size(),
+      "should have 1 error for: " + arg1)
+
+class \nodoc\ iso _PropertyHeadersRoundtrip
+  is Property1[Array[(String val, String val)] ref]
+  """
+  Headers in a response are correctly parsed and available in the
+  delivered Headers collection.
+  """
+  fun name(): String => "parser/headers_roundtrip"
+
+  fun gen(): Generator[Array[(String val, String val)] ref] =>
+    let pair_gen = Generators.zip2[String val, String val](
+      Generators.ascii_letters(1, 10),
+      Generators.ascii_letters(1, 20))
+    Generators.array_of[
+      (String val, String val)](pair_gen, 1, 5)
+
+  fun ref property(
+    arg1: Array[(String val, String val)] ref,
+    ph: PropertyHelper)
+  =>
+    var raw: String val = "HTTP/1.1 200 OK\r\n"
+    raw = raw + "Content-Length: 0\r\n"
+    for (hdr_name, hdr_value) in arg1.values() do
+      raw = raw + hdr_name + ": " + hdr_value + "\r\n"
+    end
+    raw = raw + "\r\n"
+
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response")
+    try
+      (_, _, _, let headers) = notify.responses(0)?
+      let seen = Array[String val]
+      for (hdr_name, hdr_value) in arg1.values() do
+        let lower: String val = hdr_name.lower()
+        // Skip "content-length" since we added it ourselves
+        if lower == "content-length" then continue end
+        var already_seen = false
+        for s in seen.values() do
+          if s == lower then already_seen = true; break end
+        end
+        if not already_seen then
+          seen.push(lower)
+          match headers.get(hdr_name)
+          | let v: String val =>
+            ph.assert_eq[String val](hdr_value, v,
+              "header " + hdr_name + " mismatch")
+          | None =>
+            ph.fail("header " + hdr_name + " not found")
+          end
+        end
+      end
+    else
+      ph.fail("could not read response")
+    end
+
+class \nodoc\ iso _PropertyFixedBodyDelivered
+  is Property1[USize]
+  """
+  Responses with Content-Length have their body delivered completely via
+  body_chunk callbacks, followed by response_complete.
+  """
+  fun name(): String => "parser/fixed_body_delivered"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(1, 200)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    let body = recover val
+      let b = Array[U8](arg1)
+      var i: USize = 0
+      while i < arg1 do
+        b.push('A' + (i % 26).u8())
+        i = i + 1
+      end
+      b
+    end
+
+    let raw = recover val
+      let r = String
+      r.append("HTTP/1.1 200 OK\r\n")
+      r.append("Content-Length: " + arg1.string() + "\r\n")
+      r.append("\r\n")
+      r.append(body)
+      r
+    end
+
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+
+    var total_body: USize = 0
+    for chunk in notify.body_chunks.values() do
+      total_body = total_body + chunk.size()
+    end
+    ph.assert_eq[USize](arg1, total_body, "body size mismatch")
+
+    var byte_idx: USize = 0
+    for chunk in notify.body_chunks.values() do
+      try
+        var ci: USize = 0
+        while ci < chunk.size() do
+          ph.assert_eq[U8](body(byte_idx)?, chunk(ci)?,
+            "body byte mismatch at " + byte_idx.string())
+          byte_idx = byte_idx + 1
+          ci = ci + 1
+        end
+      end
+    end
+
+class \nodoc\ iso _PropertyChunkedBodyDelivered
+  is Property1[Array[USize] ref]
+  """
+  Chunked transfer encoding delivers the complete body and
+  response_complete.
+  """
+  fun name(): String => "parser/chunked_body_delivered"
+
+  fun gen(): Generator[Array[USize] ref] =>
+    Generators.array_of[USize](Generators.usize(1, 50), 1, 5)
+
+  fun ref property(arg1: Array[USize] ref, ph: PropertyHelper) =>
+    var total_size: USize = 0
+    var raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n"
+
+    for size in arg1.values() do
+      let chunk_data: String val = recover val
+        let s = String(size)
+        var i: USize = 0
+        while i < size do
+          s.push('A' + (i % 26).u8())
+          i = i + 1
+        end
+        s
+      end
+      let hex_size: String val =
+        Format.int[USize](size where fmt = FormatHexBare)
+      raw = raw + hex_size + "\r\n" + chunk_data + "\r\n"
+      total_size = total_size + size
+    end
+    raw = raw + "0\r\n\r\n"
+
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+
+    var total_received: USize = 0
+    for chunk in notify.body_chunks.values() do
+      total_received = total_received + chunk.size()
+    end
+    ph.assert_eq[USize](total_size, total_received,
+      "total body size mismatch")
+
+class \nodoc\ iso _PropertyStatusLineBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed valid/invalid status lines: valid ones produce response_received,
+  invalid ones produce parse_error.
+  """
+  fun name(): String => "parser/status_line_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    let valid_gen: Generator[(String val, Bool)] =
+      Generators.one_of[String val](
+        ["200"; "201"; "204"; "301"; "302"; "304"
+         "400"; "401"; "403"; "404"; "500"; "502"; "503"; "599"])
+        .map[(String val, Bool)]({(status) =>
+          ("HTTP/1.1 " + status +
+           " OK\r\nContent-Length: 0\r\n\r\n", true) })
+
+    let invalid_gen: Generator[(String val, Bool)] =
+      Generators.frequency[String val]([
+        as WeightedGenerator[String val]:
+        (1, Generators.unit[String val]("HTTP/2.0 200 OK\r\n\r\n"))
+        (1, Generators.unit[String val]("HTTP/1.1 abc OK\r\n\r\n"))
+        (1, Generators.unit[String val]("GARBAGE\r\n\r\n"))
+        (1, Generators.unit[String val]("HTTP/1.1\r\n\r\n"))
+      ]).map[(String val, Bool)]({(s) => (s, false) })
+
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_gen)
+      (1, invalid_gen)
+    ])
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let raw, let should_succeed) = arg1
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    if should_succeed then
+      ph.assert_eq[USize](1, notify.responses.size(),
+        "valid response should parse")
+      ph.assert_eq[USize](0, notify.errors.size(),
+        "valid response should have no errors")
+    else
+      ph.assert_eq[USize](1, notify.errors.size(),
+        "invalid response should produce error")
+    end
+
+// ---------------------------------------------------------------------------
+// Example-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestParserKnownGoodResponses is UnitTest
+  """Verify exact callback sequences for well-known HTTP responses."""
+  fun name(): String => "parser/known_good_responses"
+
+  fun apply(h: TestHelper) =>
+    _test_simple_200(h)
+    _test_404_with_body(h)
+    _test_301_redirect(h)
+
+  fun _test_simple_200(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 5\r\n" +
+      "\r\n" +
+      "Hello"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "200: 1 response")
+    h.assert_eq[USize](1, notify.completed, "200: 1 completion")
+    try
+      (let s, let r, let v, _) = notify.responses(0)?
+      h.assert_eq[U16](200, s, "status should be 200")
+      h.assert_eq[String val]("OK", r, "reason should be OK")
+      h.assert_true(v is HTTP11, "version should be HTTP/1.1")
+    else
+      h.fail("200: could not read response")
+    end
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string(), "body should be Hello")
+
+  fun _test_404_with_body(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 404 Not Found\r\n" +
+      "Content-Length: 9\r\n" +
+      "\r\n" +
+      "Not Found"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "404: 1 response")
+    h.assert_eq[USize](1, notify.completed, "404: 1 completion")
+    try
+      (let s, let r, _, _) = notify.responses(0)?
+      h.assert_eq[U16](404, s, "status should be 404")
+      h.assert_eq[String val]("Not Found", r)
+    else
+      h.fail("404: could not read response")
+    end
+    h.assert_eq[String val](
+      "Not Found", notify.collected_body_string())
+
+  fun _test_301_redirect(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 301 Moved Permanently\r\n" +
+      "Location: https://example.com/new\r\n" +
+      "Content-Length: 0\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "301: 1 response")
+    h.assert_eq[USize](1, notify.completed, "301: 1 completion")
+    try
+      (let s, _, _, let hdrs) = notify.responses(0)?
+      h.assert_eq[U16](301, s)
+      h.assert_eq[String val](
+        "https://example.com/new",
+        match hdrs.get("Location")
+        | let v: String val => v
+        else "" end)
+    else
+      h.fail("301: could not read response")
+    end
+
+class \nodoc\ iso _TestIncrementalByteByByte is UnitTest
+  """
+  Feed a complete response one byte at a time. Verify the parser produces
+  the same result as feeding all at once.
+  """
+  fun name(): String => "parser/incremental_byte_by_byte"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 5\r\n" +
+      "\r\n" +
+      "Hello"
+
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+
+    var i: USize = 0
+    let arr = raw.array()
+    while i < arr.size() do
+      try
+        let byte = recover iso
+          let a = Array[U8](1)
+          a.push(arr(i)?)
+          a
+        end
+        parser.parse(consume byte)
+      end
+      i = i + 1
+    end
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string(), "body should be Hello")
+
+class \nodoc\ iso _TestSizeLimitStatusLine is UnitTest
+  """Status line exceeding small limit -> TooLarge."""
+  fun name(): String => "parser/size_limit_status_line"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_status_line_size' = 16)
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify, config)
+
+    let raw = "HTTP/1.1 200 OK with a long reason\r\n\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is TooLarge, "should be TooLarge")
+    end
+
+class \nodoc\ iso _TestSizeLimitHeaders is UnitTest
+  """Headers exceeding small limit -> TooLarge."""
+  fun name(): String => "parser/size_limit_headers"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_header_size' = 32)
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify, config)
+
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "X-Very-Long-Header-Name: very-long-value-that-exceeds-limit\r\n" +
+      "\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is TooLarge, "should be TooLarge")
+    end
+
+class \nodoc\ iso _TestSizeLimitBody is UnitTest
+  """Content-Length or chunked body exceeding limit -> BodyTooLarge."""
+  fun name(): String => "parser/size_limit_body"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_body_size' = 5)
+
+    // Fixed body: Content-Length 10 > max_body_size 5
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify, config)
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 10\r\n\r\n" +
+      "0123456789"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(),
+      "fixed body: should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is BodyTooLarge,
+        "fixed body: should be BodyTooLarge")
+    end
+
+    // Chunked body: 10 bytes > max_body_size 5
+    let notify2: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser2 = _ResponseParser(notify2, config)
+    let raw2: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "a\r\n0123456789\r\n0\r\n\r\n"
+    parser2.parse(recover raw2.array().clone() end)
+
+    h.assert_eq[USize](1, notify2.errors.size(),
+      "chunked body: should have 1 error")
+    try
+      h.assert_true(notify2.errors(0)? is BodyTooLarge,
+        "chunked body: should be BodyTooLarge")
+    end
+
+class \nodoc\ iso _TestSizeLimitCloseDelimitedBody is UnitTest
+  """Close-delimited body exceeding limit -> BodyTooLarge."""
+  fun name(): String => "parser/size_limit_close_delimited_body"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_body_size' = 5)
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify, config)
+
+    // Response with no CL/chunked => close-delimited
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n\r\n" +
+      "0123456789"  // 10 bytes > max 5
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is BodyTooLarge,
+        "should be BodyTooLarge")
+    end
+
+class \nodoc\ iso _TestInvalidContentLength is UnitTest
+  """Non-numeric Content-Length -> InvalidContentLength."""
+  fun name(): String => "parser/invalid_content_length"
+
+  fun apply(h: TestHelper) =>
+    let raw = "HTTP/1.1 200 OK\r\nContent-Length: abc\r\n\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidContentLength,
+        "should be InvalidContentLength")
+    end
+
+class \nodoc\ iso _TestInvalidChunkSize is UnitTest
+  """Non-hex chunk size -> InvalidChunk."""
+  fun name(): String => "parser/invalid_chunk_size"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "xyz\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidChunk,
+        "should be InvalidChunk")
+    end
+
+class \nodoc\ iso _TestChunkedWithTrailers is UnitTest
+  """Chunked response with trailer headers -> trailers skipped, completes."""
+  fun name(): String => "parser/chunked_with_trailers"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "5\r\nHello\r\n" +
+      "0\r\n" +
+      "Trailer-Header: value\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestHTTP10Version is UnitTest
+  """HTTP/1.0 response -> version is HTTP10."""
+  fun name(): String => "parser/http10_version"
+
+  fun apply(h: TestHelper) =>
+    let raw = "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size())
+    try
+      h.assert_true(notify.responses(0)?._3 is HTTP10,
+        "version should be HTTP/1.0")
+    end
+
+class \nodoc\ iso _TestInvalidVersion is UnitTest
+  """Bad version string -> InvalidVersion."""
+  fun name(): String => "parser/invalid_version"
+
+  fun apply(h: TestHelper) =>
+    _test_version(h, "HTTP/2.0")
+    _test_version(h, "HTTP/1.2")
+    _test_version(h, "HTXP/1.1")
+    _test_version(h, "HTTP/1")
+
+  fun _test_version(h: TestHelper, ver: String val) =>
+    let raw: String val = ver + " 200 OK\r\n\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+    h.assert_eq[USize](1, notify.errors.size(),
+      "should have 1 error for " + ver)
+    try
+      let err = notify.errors(0)?
+      h.assert_true(
+        (err is InvalidVersion) or (err is InvalidStatusLine),
+        "should be InvalidVersion or InvalidStatusLine for " + ver)
+    end
+
+class \nodoc\ iso _TestNoBodyHead is UnitTest
+  """HEAD response with Content-Length -> body suppressed."""
+  fun name(): String => "parser/no_body_head"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 1000\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.expect_response(HEAD)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestNoBody204 is UnitTest
+  """204 No Content -> no body regardless of headers."""
+  fun name(): String => "parser/no_body_204"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 204 No Content\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestNoBody304 is UnitTest
+  """304 Not Modified -> no body regardless of headers."""
+  fun name(): String => "parser/no_body_304"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 304 Not Modified\r\n" +
+      "Content-Length: 500\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestCloseDelimitedBody is UnitTest
+  """
+  Response with no CL/chunked: body delivered via chunks, completed by
+  connection_closed().
+  """
+  fun name(): String => "parser/close_delimited_body"
+
+  fun apply(h: TestHelper) =>
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+
+    // First chunk of data
+    let raw: String val = "HTTP/1.1 200 OK\r\n\r\nHello"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](0, notify.completed,
+      "not completed yet (close-delimited)")
+
+    // More data
+    parser.parse(recover iso " World".array().clone() end)
+
+    // Connection close signals end of body
+    parser.connection_closed()
+
+    h.assert_eq[USize](1, notify.completed, "completed after close")
+    h.assert_eq[String val](
+      "Hello World", notify.collected_body_string())
+
+class \nodoc\ iso _TestContentLengthZero is UnitTest
+  """Content-Length: 0 -> response_complete immediately (no body)."""
+  fun name(): String => "parser/content_length_zero"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 0\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
+  """
+  Both Content-Length and Transfer-Encoding: chunked -> chunked takes
+  precedence per RFC 7230 section 3.3.3.
+  """
+  fun name(): String => "parser/content_length_and_chunked"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 100\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "5\r\nHello\r\n0\r\n\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(), "1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    // Body is 5 bytes (chunked), not 100 (Content-Length)
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestDuplicateContentLength is UnitTest
+  """Two Content-Length headers with differing values -> error."""
+  fun name(): String => "parser/duplicate_content_length"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 10\r\n" +
+      "Content-Length: 20\r\n" +
+      "\r\n"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidContentLength,
+        "should be InvalidContentLength")
+    end
+
+class \nodoc\ iso _TestDataAfterError is UnitTest
+  """
+  Feed data after a parse error -> no additional callbacks fired
+  (verifies _failed short-circuit).
+  """
+  fun name(): String => "parser/data_after_error"
+
+  fun apply(h: TestHelper) =>
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+
+    // Cause an error
+    let bad = "GARBAGE_NOT_HTTP\r\n\r\n"
+    parser.parse(recover bad.array().clone() end)
+    h.assert_eq[USize](1, notify.errors.size(), "1 error after bad data")
+
+    // Feed valid data after error
+    let good = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+    parser.parse(recover good.array().clone() end)
+
+    // Should still have exactly 1 error and 0 responses
+    h.assert_eq[USize](1, notify.errors.size(),
+      "still 1 error after second parse")
+    h.assert_eq[USize](0, notify.responses.size(),
+      "0 responses (parser is failed)")
+
+class \nodoc\ iso _Test1xxSkipped is UnitTest
+  """100 Continue followed by 200 OK: only 200 delivered to handler."""
+  fun name(): String => "parser/1xx_skipped"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 100 Continue\r\n" +
+      "\r\n" +
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 2\r\n" +
+      "\r\n" +
+      "OK"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    // Only the 200 should be delivered
+    h.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response (not 2)")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    try
+      h.assert_eq[U16](200, notify.responses(0)?._1,
+        "delivered response should be 200")
+    end
+    h.assert_eq[String val](
+      "OK", notify.collected_body_string())
+
+class \nodoc\ iso _TestMultiple1xx is UnitTest
+  """Multiple 1xx responses before final response."""
+  fun name(): String => "parser/multiple_1xx"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "HTTP/1.1 100 Continue\r\n\r\n" +
+      "HTTP/1.1 102 Processing\r\n\r\n" +
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Length: 4\r\n" +
+      "\r\n" +
+      "Done"
+    let notify: _TestResponseParserNotify ref = _TestResponseParserNotify
+    let parser = _ResponseParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.responses.size(),
+      "should have 1 response")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    try
+      h.assert_eq[U16](200, notify.responses(0)?._1)
+    end
+    h.assert_eq[String val](
+      "Done", notify.collected_body_string())

--- a/courier/_test_serializer.pony
+++ b/courier/_test_serializer.pony
@@ -1,0 +1,207 @@
+use "pony_check"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertySerializerContainsMethod
+  is Property1[String val]
+  """Method string appears in the serialized request line."""
+  fun name(): String => "serializer/contains_method"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["GET"; "POST"; "PUT"; "DELETE"; "HEAD"
+       "OPTIONS"; "PATCH"; "TRACE"])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let method = match Methods.parse(arg1)
+      | let m: Method => m
+      else
+        ph.fail("should parse: " + arg1)
+        return
+      end
+    let request = HTTPRequest(method, "/test")
+    let serialized: String val =
+      String.from_iso_array(_RequestSerializer(request, "example.com", "80"))
+    // Request line starts with METHOD
+    ph.assert_true(
+      serialized.contains(arg1 + " /test HTTP/1.1\r\n"),
+      "request line should contain method: " + arg1)
+
+class \nodoc\ iso _PropertySerializerContainsPath
+  is Property1[String val]
+  """Path appears in the serialized request line."""
+  fun name(): String => "serializer/contains_path"
+
+  fun gen(): Generator[String val] =>
+    Generators.map2[String val, String val, String val](
+      Generators.unit[String val]("/"),
+      Generators.ascii_letters(0, 20),
+      {(slash, rest) => slash + rest })
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let request = HTTPRequest(GET, arg1)
+    let serialized: String val =
+      String.from_iso_array(_RequestSerializer(request, "example.com", "80"))
+    ph.assert_true(
+      serialized.contains("GET " + arg1 + " HTTP/1.1"),
+      "request line should contain path: " + arg1)
+
+class \nodoc\ iso _PropertySerializerAutoHost
+  is Property1[String val]
+  """Host header is auto-set from host parameter."""
+  fun name(): String => "serializer/auto_host"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["example.com"; "api.test.org"; "localhost"])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let request = HTTPRequest(GET, "/")
+    let serialized: String val =
+      String.from_iso_array(_RequestSerializer(request, arg1, "80"))
+    ph.assert_true(
+      serialized.contains("Host: " + arg1 + "\r\n"),
+      "should contain Host: " + arg1)
+
+class \nodoc\ iso _PropertySerializerAutoContentLength
+  is Property1[USize]
+  """Content-Length is auto-set from body size."""
+  fun name(): String => "serializer/auto_content_length"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(1, 100)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    let body = recover val
+      let b = Array[U8](arg1)
+      var i: USize = 0
+      while i < arg1 do
+        b.push('X')
+        i = i + 1
+      end
+      b
+    end
+    let request = HTTPRequest(POST, "/data" where body' = body)
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "example.com", "80"))
+    ph.assert_true(
+      serialized.contains(
+        "Content-Length: " + arg1.string() + "\r\n"),
+      "should contain Content-Length: " + arg1.string())
+
+// ---------------------------------------------------------------------------
+// Example-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestSerializerKnownGood is UnitTest
+  """Known request -> known wire bytes."""
+  fun name(): String => "serializer/known_good"
+
+  fun apply(h: TestHelper) =>
+    let request = HTTPRequest(GET, "/index.html")
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "www.example.com", "80"))
+
+    let expected: String val =
+      "GET /index.html HTTP/1.1\r\n" +
+      "Host: www.example.com\r\n" +
+      "\r\n"
+    h.assert_eq[String val](expected, serialized)
+
+class \nodoc\ iso _TestSerializerHostWithPort is UnitTest
+  """Non-standard port included in Host header."""
+  fun name(): String => "serializer/host_with_port"
+
+  fun apply(h: TestHelper) =>
+    let request = HTTPRequest(GET, "/")
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "example.com", "8080"))
+    h.assert_true(
+      serialized.contains("Host: example.com:8080\r\n"),
+      "Host should include port 8080")
+
+class \nodoc\ iso _TestSerializerHostDefaultPort is UnitTest
+  """Port 80 and 443 omitted from Host header."""
+  fun name(): String => "serializer/host_default_port"
+
+  fun apply(h: TestHelper) =>
+    // Port 80
+    let s80: String val =
+      String.from_iso_array(
+        _RequestSerializer(HTTPRequest(GET, "/"), "example.com", "80"))
+    h.assert_true(
+      s80.contains("Host: example.com\r\n"),
+      "port 80 should be omitted")
+    h.assert_false(
+      s80.contains("Host: example.com:80\r\n"),
+      "port 80 should not appear")
+
+    // Port 443
+    let s443: String val =
+      String.from_iso_array(
+        _RequestSerializer(HTTPRequest(GET, "/"), "example.com", "443"))
+    h.assert_true(
+      s443.contains("Host: example.com\r\n"),
+      "port 443 should be omitted")
+
+class \nodoc\ iso _TestSerializerUserHostTakesPrecedence is UnitTest
+  """Explicit Host header is not overwritten."""
+  fun name(): String => "serializer/user_host_precedence"
+
+  fun apply(h: TestHelper) =>
+    let hdrs = recover val
+      let h' = Headers
+      h'.set("Host", "custom.host.com")
+      h'
+    end
+    let request = HTTPRequest(GET, "/" where headers' = hdrs)
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "example.com", "80"))
+    h.assert_true(
+      serialized.contains("host: custom.host.com\r\n"),
+      "should use user-provided Host")
+    // Should NOT also have auto-generated Host
+    h.assert_false(
+      serialized.contains("Host: example.com"),
+      "should not auto-generate Host when user provided one")
+
+class \nodoc\ iso _TestSerializerUserContentLengthTakesPrecedence
+  is UnitTest
+  """Explicit Content-Length is not overwritten."""
+  fun name(): String => "serializer/user_content_length_precedence"
+
+  fun apply(h: TestHelper) =>
+    let body: Array[U8] val = [as U8: 'H'; 'i']
+    let hdrs = recover val
+      let h' = Headers
+      h'.set("Content-Length", "999")
+      h'
+    end
+    let request = HTTPRequest(POST, "/data"
+      where headers' = hdrs, body' = body)
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "example.com", "80"))
+    h.assert_true(
+      serialized.contains("content-length: 999\r\n"),
+      "should use user-provided Content-Length")
+
+class \nodoc\ iso _TestSerializerNoBody is UnitTest
+  """No body -> no Content-Length."""
+  fun name(): String => "serializer/no_body"
+
+  fun apply(h: TestHelper) =>
+    let request = HTTPRequest(GET, "/")
+    let serialized: String val =
+      String.from_iso_array(
+        _RequestSerializer(request, "example.com", "80"))
+    h.assert_false(
+      serialized.contains("Content-Length"),
+      "GET with no body should not have Content-Length")

--- a/courier/client_connection_config.pony
+++ b/courier/client_connection_config.pony
@@ -1,0 +1,74 @@
+use lori = "lori"
+
+primitive _DefaultIdleTimeout
+  """60-second idle timeout, the default for HTTP client connections."""
+  fun apply(): (lori.IdleTimeout | None) =>
+    match lori.MakeIdleTimeout(60_000)
+    | let t: lori.IdleTimeout => t
+    else
+      _Unreachable()
+      None
+    end
+
+class val ClientConnectionConfig
+  """
+  Configuration for an HTTP client connection.
+
+  Parser limits control the maximum size of response components. Idle timeout
+  controls how long the connection can sit without I/O activity before the
+  library closes it. `from` specifies the local bind address (empty string
+  means any interface).
+
+  ```pony
+  // All defaults (60-second idle timeout, 10 MB max body)
+  ClientConnectionConfig
+
+  // Custom timeout via MakeIdleTimeout (milliseconds)
+  let timeout = match lori.MakeIdleTimeout(30_000)
+  | let t: lori.IdleTimeout => t
+  end
+  ClientConnectionConfig(where
+    max_body_size' = 52_428_800,  // 50 MB
+    idle_timeout' = timeout)
+
+  // Disable idle timeout
+  ClientConnectionConfig(where idle_timeout' = None)
+  ```
+  """
+  let max_status_line_size: USize
+  let max_header_size: USize
+  let max_chunk_header_size: USize
+  let max_body_size: USize
+  let idle_timeout: (lori.IdleTimeout | None)
+  let from: String
+
+  new val create(
+    max_status_line_size': USize = 8192,
+    max_header_size': USize = 8192,
+    max_chunk_header_size': USize = 128,
+    max_body_size': USize = 10_485_760,
+    idle_timeout': (lori.IdleTimeout | None) = _DefaultIdleTimeout(),
+    from': String = "")
+  =>
+    """
+    Create client connection configuration.
+
+    Parser limits default to sensible values. `idle_timeout'` is an
+    `IdleTimeout` (milliseconds) or `None` to disable idle timeout. Defaults
+    to 60 seconds. `from'` specifies the local bind address (empty string
+    means any interface).
+    """
+    max_status_line_size = max_status_line_size'
+    max_header_size = max_header_size'
+    max_chunk_header_size = max_chunk_header_size'
+    max_body_size = max_body_size'
+    idle_timeout = idle_timeout'
+    from = from'
+
+  fun _parser_config(): _ParserConfig val =>
+    """Create a parser config from the parser limit fields."""
+    _ParserConfig(
+      max_status_line_size,
+      max_header_size,
+      max_chunk_header_size,
+      max_body_size)

--- a/courier/courier.pony
+++ b/courier/courier.pony
@@ -1,3 +1,64 @@
 """
 courier — HTTP client for Pony.
+
+Courier is an HTTP/1.1 client library built on
+[lori](https://github.com/ponylang/lori). It follows the same architectural
+pattern as lori and [stallion](https://github.com/ponylang/stallion): a
+protocol handler class (`HTTPClientConnection`) owned by the user's actor,
+with synchronous `fun ref` callbacks. No hidden actors.
+
+## Getting Started
+
+Implement `HTTPClientConnectionActor` on your actor, store an
+`HTTPClientConnection` as a field, and override the lifecycle callbacks
+you need:
+
+```pony
+use "courier"
+use lori = "lori"
+
+actor MyClient is HTTPClientConnectionActor
+  var _http: HTTPClientConnection = HTTPClientConnection.none()
+  let _out: OutStream
+
+  new create(auth: lori.TCPConnectAuth, host: String, port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _http = HTTPClientConnection(auth, host, port, this,
+      ClientConnectionConfig)
+
+  fun ref _http_client_connection(): HTTPClientConnection => _http
+
+  fun ref on_connected() =>
+    _http.send_request(HTTPRequest(GET, "/"))
+
+  fun ref on_response(response: Response val) =>
+    _out.print(response.status.string() + " " + response.reason)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _out.write(data)
+
+  fun ref on_response_complete() =>
+    _out.print("")
+    _http.close()
+```
+
+For HTTPS, use `HTTPClientConnection.ssl()` instead of
+`HTTPClientConnection()`.
+
+## Key Types
+
+- `HTTPClientConnectionActor` — trait for your actor
+- `HTTPClientConnection` — protocol handler class (stored as actor field)
+- `HTTPClientLifecycleEventReceiver` — callback trait (default no-ops)
+- `HTTPRequest` — request data (method, path, headers, body)
+- `Response` — parsed response metadata (version, status, reason, headers)
+- `ClientConnectionConfig` — parser limits, idle timeout, bind address
+- `SendRequestResult` — result of `send_request()` (success or error)
+
+## Design
+
+See [Discussion #2](https://github.com/ponylang/courier/discussions/2) for
+the full design rationale.
 """

--- a/courier/headers.pony
+++ b/courier/headers.pony
@@ -1,0 +1,64 @@
+class Headers
+  """
+  A collection of HTTP headers with case-insensitive name lookup.
+
+  Names are lowercased on storage. Use `set()` to replace all values for a
+  name, or `add()` to append an additional value (appropriate for multi-value
+  headers like Set-Cookie).
+  """
+  embed _headers: Array[(String, String)]
+
+  new create() =>
+    """Create an empty header collection."""
+    _headers = Array[(String, String)]
+
+  fun ref set(name: String, value: String) =>
+    """
+    Set a header, removing any existing entries with the same name.
+
+    After this call, `get(name)` returns `value` and there is exactly one
+    entry for this name.
+    """
+    let lower_name: String val = name.lower()
+    var i: USize = 0
+    while i < _headers.size() do
+      try
+        if _headers(i)?._1 == lower_name then
+          _headers.delete(i)?
+        else
+          i = i + 1
+        end
+      else
+        i = i + 1
+      end
+    end
+    _headers.push((lower_name, value))
+
+  fun ref add(name: String, value: String) =>
+    """
+    Add a header entry without removing existing entries with the same name.
+
+    This is appropriate for headers that can appear multiple times
+    (e.g., Set-Cookie). Use `set()` when you want to replace.
+    """
+    _headers.push((name.lower(), value))
+
+  fun get(name: String): (String | None) =>
+    """
+    Get the first value for the given header name (case-insensitive).
+
+    Returns `None` if no header with that name exists.
+    """
+    let lower_name: String val = name.lower()
+    for (n, v) in _headers.values() do
+      if n == lower_name then return v end
+    end
+    None
+
+  fun size(): USize =>
+    """Return the number of header entries."""
+    _headers.size()
+
+  fun values(): ArrayValues[(String, String), this->Array[(String, String)]] =>
+    """Iterate over all header entries as (name, value) pairs."""
+    _headers.values()

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -1,0 +1,287 @@
+use lori = "lori"
+use ssl_net = "ssl/net"
+
+primitive _Idle
+primitive _AwaitingResponse
+
+class HTTPClientConnection is
+  (lori.ClientLifecycleEventReceiver & _ResponseParserNotify)
+  """
+  HTTP protocol handler that manages request serialization, response parsing,
+  and connection lifecycle for a single HTTP client connection.
+
+  Stored as a field inside an `HTTPClientConnectionActor`. Handles all
+  HTTP-level concerns — serializing outgoing requests, parsing incoming
+  responses, idle timeout scheduling, and backpressure — and delivers
+  HTTP events to the actor via `HTTPClientLifecycleEventReceiver` callbacks.
+
+  The protocol class implements lori's `ClientLifecycleEventReceiver`
+  to receive TCP-level events from the connection, and
+  `_ResponseParserNotify` to receive parser callbacks. It forwards
+  HTTP-level events to the owning actor.
+
+  Use `none()` as the field default so that `this` is `ref` in the
+  actor constructor body, then replace with `create()` or `ssl()`:
+
+  ```pony
+  actor MyClient is HTTPClientConnectionActor
+    var _http: HTTPClientConnection = HTTPClientConnection.none()
+
+    new create(auth: lori.TCPConnectAuth, host: String, port: String,
+      config: ClientConnectionConfig)
+    =>
+      _http = HTTPClientConnection(auth, host, port, this, config)
+  ```
+  """
+  let _lifecycle_event_receiver:
+    (HTTPClientLifecycleEventReceiver ref | None)
+  let _config: (ClientConnectionConfig | None)
+  let _host: String
+  let _port: String
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _state: _ConnectionState = _Active
+  var _request_state: (_Idle | _AwaitingResponse) = _Idle
+  var _parser: (_ResponseParser | None) = None
+
+  new none() =>
+    """
+    Create a placeholder protocol instance.
+
+    Used as the default value for the `_http` field in
+    `HTTPClientConnectionActor` implementations, allowing `this` to be `ref`
+    in the actor constructor body. The placeholder is immediately replaced
+    by `create()` or `ssl()` — its methods must never be called.
+    """
+    _lifecycle_event_receiver = None
+    _config = None
+    _host = ""
+    _port = ""
+
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    client_actor: HTTPClientConnectionActor ref,
+    config: ClientConnectionConfig)
+  =>
+    """
+    Create the protocol handler for a plain HTTP connection.
+
+    Called inside the `HTTPClientConnectionActor` constructor. The
+    `client_actor` parameter must be the actor's `this` — it provides the
+    `HTTPClientLifecycleEventReceiver ref` for synchronous HTTP callbacks.
+    """
+    _lifecycle_event_receiver = client_actor
+    _config = config
+    _host = host
+    _port = port
+    _parser = _ResponseParser(this, config._parser_config())
+    _tcp_connection =
+      lori.TCPConnection.client(auth, host, port, config.from,
+        client_actor, this)
+
+  new ssl(
+    auth: lori.TCPConnectAuth,
+    ssl_ctx: ssl_net.SSLContext val,
+    host: String,
+    port: String,
+    client_actor: HTTPClientConnectionActor ref,
+    config: ClientConnectionConfig)
+  =>
+    """
+    Create the protocol handler for an HTTPS connection.
+
+    Like `create`, but wraps the TCP connection in SSL using the provided
+    `SSLContext`. Called inside the `HTTPClientConnectionActor` constructor
+    for HTTPS connections.
+    """
+    _lifecycle_event_receiver = client_actor
+    _config = config
+    _host = host
+    _port = port
+    _parser = _ResponseParser(this, config._parser_config())
+    _tcp_connection =
+      lori.TCPConnection.ssl_client(auth, ssl_ctx, host, port,
+        config.from, client_actor, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    """Return the underlying TCP connection."""
+    _tcp_connection
+
+  fun ref send_request(request: HTTPRequest val): SendRequestResult =>
+    """
+    Serialize and send an HTTP request.
+
+    Returns `SendRequestOK` on success, `ConnectionClosed` if the connection
+    is not open, or `ResponsePending` if a response to a previous request
+    is still in progress.
+
+    Auto-sets `Host` and `Content-Length` headers during serialization if
+    they are not already present in the request.
+    """
+    match _state
+    | let _: _Closed => return ConnectionClosed
+    end
+
+    match _request_state
+    | let _: _AwaitingResponse => return ResponsePending
+    end
+
+    match _parser
+    | let p: _ResponseParser => p.expect_response(request.method)
+    end
+
+    let serialized = _RequestSerializer(request, _host, _port)
+    match _tcp_connection.send(consume serialized)
+    | let _: lori.SendError =>
+      _close_connection()
+      return ConnectionClosed
+    end
+
+    _request_state = _AwaitingResponse
+    SendRequestOK
+
+  fun ref close() =>
+    """
+    Close the connection.
+
+    Safe to call at any time; idempotent due to the `_Active` state guard
+    in `_close_connection()`.
+    """
+    _close_connection()
+
+  //
+  // ClientLifecycleEventReceiver
+  //
+
+  fun ref _on_connected() =>
+    match _config
+    | let c: ClientConnectionConfig =>
+      _tcp_connection.idle_timeout(c.idle_timeout)
+    end
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref => r.on_connected()
+    end
+
+  fun ref _on_connection_failure() =>
+    _state = _Closed
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref =>
+      r.on_connection_failure()
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _state.on_received(this, consume data)
+
+  fun ref _on_closed() =>
+    _state.on_closed(this)
+
+  fun ref _on_throttled() =>
+    _state.on_throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _state.on_unthrottled(this)
+
+  fun ref _on_idle_timeout() =>
+    _state.on_idle_timeout(this)
+
+  //
+  // _ResponseParserNotify — forwarding parser events to receiver
+  //
+
+  fun ref response_received(
+    status: U16,
+    reason: String val,
+    version: Version,
+    headers: Headers val)
+  =>
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref =>
+      r.on_response(Response(version, status, reason, headers))
+    end
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref =>
+      r.on_body_chunk(data)
+    end
+
+  fun ref response_complete() =>
+    _request_state = _Idle
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref =>
+      r.on_response_complete()
+    end
+
+  fun ref parse_error(err: ParseError) =>
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref =>
+      r.on_parse_error(err)
+    end
+    _close_connection()
+
+  //
+  // Internal methods called by state classes
+  //
+
+  fun ref _feed_parser(data: Array[U8] iso) =>
+    """Feed incoming data to the response parser."""
+    match _parser
+    | let p: _ResponseParser => p.parse(consume data)
+    end
+
+  fun ref _handle_closed() =>
+    """
+    Handle remote connection close.
+
+    For close-delimited bodies, `parser.connection_closed()` completes the
+    response. For all other states, this just cleans up.
+    """
+    match _parser
+    | let p: _ResponseParser =>
+      p.connection_closed()
+      p.stop()
+    end
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref => r.on_closed()
+    end
+    _state = _Closed
+
+  fun ref _handle_throttled() =>
+    """Apply backpressure: mute the TCP connection and notify the receiver."""
+    _tcp_connection.mute()
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref => r.on_throttled()
+    end
+
+  fun ref _handle_unthrottled() =>
+    """Release backpressure: unmute the TCP connection and notify."""
+    _tcp_connection.unmute()
+    match _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref => r.on_unthrottled()
+    end
+
+  fun ref _handle_idle_timeout() =>
+    """Close the connection on idle timeout."""
+    _close_connection()
+
+  fun ref _close_connection() =>
+    """
+    Close the connection and clean up all resources.
+
+    User-initiated close does NOT call `parser.connection_closed()` — the
+    user knows the response is abandoned. Remote close goes through
+    `_handle_closed()` which does call `parser.connection_closed()`.
+
+    Safe to call from within parser callbacks — the `_Active` state guard
+    prevents double-close.
+    """
+    match _state
+    | let _: _Active =>
+      match _parser | let p: _ResponseParser => p.stop() end
+      match _lifecycle_event_receiver
+      | let r: HTTPClientLifecycleEventReceiver ref => r.on_closed()
+      end
+      _tcp_connection.close()
+      _state = _Closed
+    end

--- a/courier/http_client_connection_actor.pony
+++ b/courier/http_client_connection_actor.pony
@@ -1,0 +1,57 @@
+use lori = "lori"
+
+trait tag HTTPClientConnectionActor is
+  (lori.TCPConnectionActor & HTTPClientLifecycleEventReceiver)
+  """
+  Trait for actors that make HTTP client connections.
+
+  Extends `TCPConnectionActor` (for lori ASIO plumbing) and
+  `HTTPClientLifecycleEventReceiver` (for HTTP-level callbacks). The
+  actor stores an `HTTPClientConnection` as a field and implements
+  `_http_client_connection()` to return it. All other required methods have
+  default implementations that delegate to the protocol.
+
+  Minimal implementation:
+
+  ```pony
+  actor MyClient is HTTPClientConnectionActor
+    var _http: HTTPClientConnection = HTTPClientConnection.none()
+
+    new create(auth: lori.TCPConnectAuth, host: String, port: String,
+      config: ClientConnectionConfig)
+    =>
+      _http = HTTPClientConnection(auth, host, port, this, config)
+
+    fun ref _http_client_connection(): HTTPClientConnection => _http
+
+    fun ref on_connected() =>
+      let request = HTTPRequest(GET, "/")
+      _http.send_request(request)
+
+    fun ref on_response(version: Version, status: U16,
+      reason: String val, headers: Headers val)
+    =>
+      // process response
+      None
+  ```
+
+  For HTTPS, use `HTTPClientConnection.ssl(auth, ssl_ctx, host, port,
+  this, config)` instead of `HTTPClientConnection(auth, host, port,
+  this, config)`.
+
+  The `none()` default ensures all fields are initialized before the
+  constructor body runs, so `this` is `ref` when passed to
+  `HTTPClientConnection.create()` or `HTTPClientConnection.ssl()`.
+  """
+
+  fun ref _http_client_connection(): HTTPClientConnection
+    """
+    Return the protocol instance owned by this actor.
+
+    Called by the default implementation of `_connection()`. Must return
+    the same instance every time.
+    """
+
+  fun ref _connection(): lori.TCPConnection =>
+    """Delegates to the protocol's TCP connection."""
+    _http_client_connection()._connection()

--- a/courier/http_client_lifecycle_event_receiver.pony
+++ b/courier/http_client_lifecycle_event_receiver.pony
@@ -1,0 +1,96 @@
+trait ref HTTPClientLifecycleEventReceiver
+  """
+  HTTP response lifecycle callbacks delivered to the client actor.
+
+  All callbacks have default no-op implementations. Override only the
+  callbacks your actor needs. Callbacks are invoked synchronously inside
+  the actor that owns the `HTTPClientConnection`.
+
+  Typical usage: override `on_connected()` to send the first request,
+  `on_response()` and `on_body_chunk()` to process the response, and
+  `on_response_complete()` to send follow-up requests or close.
+  """
+
+  fun ref on_connected() =>
+    """
+    Called when the connection is ready for application data.
+
+    For plain TCP connections, this fires after TCP connect. For SSL
+    connections, this fires after the TLS handshake completes. Safe to call
+    `send_request()` from this callback.
+    """
+    None
+
+  fun ref on_connection_failure() =>
+    """
+    Called when a connection attempt fails.
+
+    Covers TCP connection failure and SSL handshake failure (for connections
+    created with `HTTPClientConnection.ssl()`). The connection is unusable
+    after this callback.
+    """
+    None
+
+  fun ref on_response(response: Response val) =>
+    """
+    Called when the response status line and all headers have been parsed.
+
+    For responses with a body, `on_body_chunk()` calls follow. For responses
+    without a body (HEAD, 204, 304), `on_response_complete()` is called
+    immediately after.
+    """
+    None
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    """
+    Called for each chunk of response body data as it arrives.
+
+    Body data is delivered incrementally. Accumulate chunks manually if
+    you need the complete body before processing.
+    """
+    None
+
+  fun ref on_response_complete() =>
+    """
+    Called when the entire response (including any body) has been received.
+
+    After this call, the connection is ready for another `send_request()`
+    (connection reuse / keep-alive).
+    """
+    None
+
+  fun ref on_parse_error(err: ParseError) =>
+    """
+    Called when a response parse error is encountered.
+
+    The connection is closed after this callback. No further callbacks
+    will be delivered except `on_closed()`.
+    """
+    None
+
+  fun ref on_closed() =>
+    """
+    Called when the connection closes.
+
+    Fires on remote disconnect, local close, idle timeout, or any other
+    reason. Not called if the connection fails before connecting (use
+    `on_connection_failure()` for that case).
+    """
+    None
+
+  fun ref on_throttled() =>
+    """
+    Called when backpressure is applied on the connection.
+
+    The TCP send buffer is full — avoid sending more requests until
+    `on_unthrottled()` is called.
+    """
+    None
+
+  fun ref on_unthrottled() =>
+    """
+    Called when backpressure is released on the connection.
+
+    The TCP send buffer has drained — request sending may resume.
+    """
+    None

--- a/courier/http_request.pony
+++ b/courier/http_request.pony
@@ -1,0 +1,28 @@
+class val HTTPRequest
+  """
+  An HTTP request to be sent by `HTTPClientConnection`.
+
+  Holds the method, path, headers, and optional body. The connection layer
+  auto-sets `Host` and `Content-Length` headers during serialization if they
+  are not already present — callers only need to set them explicitly when
+  overriding the defaults.
+
+  No validation is performed on the request — the client sends whatever the
+  caller asks for.
+  """
+  let method: Method
+  let path: String
+  let headers: Headers val
+  let body: (Array[U8] val | None)
+
+  new val create(
+    method': Method,
+    path': String,
+    headers': Headers val = recover val Headers end,
+    body': (Array[U8] val | None) = None)
+  =>
+    """Create an HTTP request with the given method, path, headers, and body."""
+    method = method'
+    path = path'
+    headers = headers'
+    body = body'

--- a/courier/method.pony
+++ b/courier/method.pony
@@ -1,0 +1,70 @@
+interface val Method is (Equatable[Method] & Stringable)
+  """An HTTP request method (RFC 7231)."""
+
+primitive GET is Method
+  """HTTP GET method."""
+  fun string(): String iso^ => "GET".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive HEAD is Method
+  """HTTP HEAD method."""
+  fun string(): String iso^ => "HEAD".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive POST is Method
+  """HTTP POST method."""
+  fun string(): String iso^ => "POST".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive PUT is Method
+  """HTTP PUT method."""
+  fun string(): String iso^ => "PUT".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive DELETE is Method
+  """HTTP DELETE method."""
+  fun string(): String iso^ => "DELETE".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive CONNECT is Method
+  """HTTP CONNECT method."""
+  fun string(): String iso^ => "CONNECT".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive OPTIONS is Method
+  """HTTP OPTIONS method."""
+  fun string(): String iso^ => "OPTIONS".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive TRACE is Method
+  """HTTP TRACE method."""
+  fun string(): String iso^ => "TRACE".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive PATCH is Method
+  """HTTP PATCH method."""
+  fun string(): String iso^ => "PATCH".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive Methods
+  """Parse HTTP method strings and enumerate known methods."""
+
+  fun parse(data: String): (Method | None) =>
+    """Parse a string into an HTTP method, or None if not recognized."""
+    match data
+    | "GET" => GET
+    | "HEAD" => HEAD
+    | "POST" => POST
+    | "PUT" => PUT
+    | "DELETE" => DELETE
+    | "CONNECT" => CONNECT
+    | "OPTIONS" => OPTIONS
+    | "TRACE" => TRACE
+    | "PATCH" => PATCH
+    else
+      None
+    end
+
+  fun valid(): Array[Method] val =>
+    """Return all standard HTTP methods."""
+    [GET; HEAD; POST; PUT; DELETE; CONNECT; OPTIONS; TRACE; PATCH]

--- a/courier/parse_error.pony
+++ b/courier/parse_error.pony
@@ -1,0 +1,34 @@
+interface val _ParseError is Stringable
+
+primitive TooLarge is _ParseError
+  """Status line or headers exceed the configured size limit."""
+  fun string(): String iso^ => "TooLarge".clone()
+
+primitive InvalidStatusLine is _ParseError
+  """Response status line is malformed."""
+  fun string(): String iso^ => "InvalidStatusLine".clone()
+
+primitive InvalidVersion is _ParseError
+  """HTTP version is not HTTP/1.0 or HTTP/1.1."""
+  fun string(): String iso^ => "InvalidVersion".clone()
+
+primitive MalformedHeaders is _ParseError
+  """Header syntax is invalid (missing colon, obs-fold continuation line)."""
+  fun string(): String iso^ => "MalformedHeaders".clone()
+
+primitive InvalidContentLength is _ParseError
+  """Content-Length is non-numeric, negative, or has conflicting values."""
+  fun string(): String iso^ => "InvalidContentLength".clone()
+
+primitive InvalidChunk is _ParseError
+  """Chunked transfer encoding error: bad chunk size or missing CRLF."""
+  fun string(): String iso^ => "InvalidChunk".clone()
+
+primitive BodyTooLarge is _ParseError
+  """Response body exceeds the configured maximum body size."""
+  fun string(): String iso^ => "BodyTooLarge".clone()
+
+type ParseError is
+  ((TooLarge | InvalidStatusLine | InvalidVersion | MalformedHeaders
+  | InvalidContentLength | InvalidChunk | BodyTooLarge) & _ParseError)
+  """Parse error encountered during HTTP response parsing."""

--- a/courier/response.pony
+++ b/courier/response.pony
@@ -1,0 +1,24 @@
+class val Response
+  """
+  Parsed HTTP response metadata (status line and headers).
+
+  Delivered via `on_response()` after the status line and all headers have
+  been parsed. For responses with a body, `on_body_chunk()` calls follow.
+  For responses without a body (HEAD, 204, 304), `on_response_complete()`
+  is called immediately after.
+  """
+  let version: Version
+  let status: U16
+  let reason: String val
+  let headers: Headers val
+
+  new val create(
+    version': Version,
+    status': U16,
+    reason': String val,
+    headers': Headers val)
+  =>
+    version = version'
+    status = status'
+    reason = reason'
+    headers = headers'

--- a/courier/send_request_result.pony
+++ b/courier/send_request_result.pony
@@ -1,0 +1,14 @@
+primitive SendRequestOK
+  """Request was serialized and sent successfully."""
+
+primitive ConnectionClosed
+  """Connection is not open, or a send failed and the connection was closed."""
+
+primitive ResponsePending
+  """A response to a previous request is still in progress."""
+
+type SendRequestError is (ConnectionClosed | ResponsePending)
+  """Error returned by `send_request()` when the request cannot be sent."""
+
+type SendRequestResult is (SendRequestOK | SendRequestError)
+  """Result of `send_request()`: either success or an error."""

--- a/courier/version.pony
+++ b/courier/version.pony
@@ -1,0 +1,14 @@
+interface val _Version is (Equatable[Version] & Stringable)
+
+primitive HTTP10 is _Version
+  """HTTP/1.0 protocol version."""
+  fun string(): String iso^ => "HTTP/1.0".clone()
+  fun eq(that: Version): Bool => that is this
+
+primitive HTTP11 is _Version
+  """HTTP/1.1 protocol version."""
+  fun string(): String iso^ => "HTTP/1.1".clone()
+  fun eq(that: Version): Bool => that is this
+
+type Version is ((HTTP10 | HTTP11) & _Version)
+  """HTTP protocol version, either HTTP/1.0 or HTTP/1.1."""

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,4 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 
 ## [basic](basic/)
 
-Prints a greeting. This is a placeholder that will be replaced with a real HTTP client example once the library API is implemented. Start here if you're new to the library.
+Connects to `example.com:80`, sends an HTTP GET request for `/`, and prints the response status, headers, and body to stdout. Demonstrates the full lifecycle: `HTTPClientConnectionActor` implementation, `on_connected` to send the request, response callbacks for status/headers/body, and connection close after completion.

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -1,3 +1,54 @@
+use "../../courier"
+use lori = "lori"
+
 actor Main
   new create(env: Env) =>
-    env.out.print("Hello from courier!")
+    let auth = lori.TCPConnectAuth(env.root)
+    BasicClient(auth, "example.com", "80", env.out)
+
+actor BasicClient is HTTPClientConnectionActor
+  """
+  Simple HTTP client that sends a GET request and prints the response.
+
+  Usage: ./basic
+  Connects to example.com:80, sends GET /, prints status and body.
+  Requires network access. The program exits after receiving the response.
+  """
+  var _http: HTTPClientConnection = HTTPClientConnection.none()
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _http = HTTPClientConnection(auth, host, port, this,
+      ClientConnectionConfig)
+
+  fun ref _http_client_connection(): HTTPClientConnection => _http
+
+  fun ref on_connected() =>
+    _http.send_request(HTTPRequest(GET, "/"))
+
+  fun ref on_connection_failure() =>
+    _out.print("Connection failed")
+
+  fun ref on_response(response: Response val) =>
+    _out.print("< " + response.version.string() + " "
+      + response.status.string() + " " + response.reason)
+    for (name, value) in response.headers.values() do
+      _out.print("< " + name + ": " + value)
+    end
+    _out.print("")
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _out.write(data)
+
+  fun ref on_response_complete() =>
+    _out.print("")
+    _http.close()
+
+  fun ref on_closed() =>
+    _out.print("Connection closed")


### PR DESCRIPTION
Implements the foundational protocol layer for courier, following the same architectural pattern as lori and stallion: a protocol handler class (`HTTPClientConnection`) owned by the user's actor, with synchronous `fun ref` callbacks via `HTTPClientLifecycleEventReceiver`. No hidden actors.

- Foundation types: `Method`, `Headers`, `Version`, `ParseError`, `HTTPRequest`
- Response parser: full HTTP/1.1 parser with fixed-length, chunked, and close-delimited body support; RFC 7230 §3.3.3 compliant (1xx discarding, HEAD/204/304 body suppression, chunked precedence)
- Request serializer: `HTTPRequest` to wire format with auto-Host and auto-Content-Length
- Connection layer: `HTTPClientConnection` with plain TCP and SSL constructors, idle timeout, backpressure routing, explicit `SendRequestResult` return type
- 43 tests: 10 property-based + 33 example-based covering parser, serializer, and foundation types
- Working `examples/basic` demonstrating the full client lifecycle

Design: #4