### PR TITLE
Rewrite README for first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,54 @@ You'll also need an SSL library installed on your platform. See the [ssl](https:
 
 ## Usage
 
-See the [examples](examples/) directory.
+```pony
+use "courier"
+use lori = "lori"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPConnectAuth(env.root)
+    BasicClient(auth, "example.com", "80", env.out)
+
+actor BasicClient is HTTPClientConnectionActor
+  var _http: HTTPClientConnection = HTTPClientConnection.none()
+  var _collector: ResponseCollector = ResponseCollector
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _http = HTTPClientConnection(auth, host, port, this,
+      ClientConnectionConfig)
+
+  fun ref _http_client_connection(): HTTPClientConnection => _http
+
+  fun ref on_connected() =>
+    _http.send_request(Request.get("/").build())
+
+  fun ref on_response(response: Response val) =>
+    _collector = ResponseCollector
+    _collector.set_response(response)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _collector.add_chunk(data)
+
+  fun ref on_response_complete() =>
+    try
+      let response = _collector.build()?
+      _out.print(String.from_array(response.body))
+    end
+    _http.close()
+
+  fun ref on_closed() =>
+    _out.print("Connection closed")
+```
+
+See the [examples](examples/) directory for more.
 
 ## API Documentation
 


### PR DESCRIPTION
Update the README to reflect courier's current state ahead of the first
release. The old README described courier as pre-alpha with an undefined
API and linked to the deprecated net-ssl package.

Changes:
- Status updated from pre-alpha to beta (using lori's established wording)
- Intro expanded to mention HTTP/1.1 and protocol-handler-owned-by-actor pattern
- SSL link corrected from net-ssl to ssl
- Installation version set to 0.1.0
- Usage section added pointing to examples/