### PR TITLE
Add typed JSON decoding interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,9 @@ Courier follows the same pattern as lori and stallion: protocol handler class ow
 
 **JSON utilities:**
 - `ResponseJson` — primitive, parses `HTTPResponse.body` as JSON via json-ng, returns `(JsonValue | JsonParseError)`
+- `JsonDecodeError` — `class val ... is Stringable`, structural mismatch when decoding parsed JSON (wrong field types, missing fields)
+- `JsonDecoder[A]` — `interface val`, converts `JsonValue` into typed domain object `A` or `JsonDecodeError`
+- `DecodeJson[A]` — primitive, combines `ResponseJson` + `JsonDecoder` into single call, returns `(A | JsonParseError | JsonDecodeError)`
 
 ### Key Design Decisions
 

--- a/courier/_test.pony
+++ b/courier/_test.pony
@@ -139,3 +139,17 @@ actor \nodoc\ Main is TestList
     test(_TestResponseJsonValidArray)
     test(_TestResponseJsonInvalid)
     test(_TestResponseJsonEmptyBody)
+
+    // JSON decoder property-based tests
+    test(Property1UnitTest[String val](_PropertyDecodeJsonParseErrorPropagation))
+    test(Property1UnitTest[String val](_PropertyDecodeJsonDecodeErrorPropagation))
+    test(Property1UnitTest[String val](_PropertyDecodeJsonIdentityDecoder))
+
+    // JSON decoder example-based tests
+    test(_TestJsonDecoderSuccessfulDecode)
+    test(_TestJsonDecoderMissingField)
+    test(_TestJsonDecoderWrongType)
+    test(_TestDecodeJsonValidJson)
+    test(_TestDecodeJsonInvalidJson)
+    test(_TestDecodeJsonWrongStructure)
+    test(_TestJsonDecodeErrorString)

--- a/courier/_test_json_decoder.pony
+++ b/courier/_test_json_decoder.pony
@@ -1,0 +1,216 @@
+use json = "json"
+use "pony_check"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _Todo
+  let id: I64
+  let title: String
+
+  new val create(id': I64, title': String) =>
+    id = id'
+    title = title'
+
+primitive \nodoc\ _TodoDecoder is JsonDecoder[_Todo]
+  fun apply(value: json.JsonValue): (_Todo | JsonDecodeError) =>
+    let nav = json.JsonNav(value)
+    try
+      _Todo(nav("id").as_i64()?, nav("title").as_string()?)
+    else
+      JsonDecodeError(
+        "expected object with integer 'id' and string 'title'")
+    end
+
+primitive \nodoc\ _AlwaysSucceedDecoder is JsonDecoder[String]
+  fun apply(value: json.JsonValue): (String | JsonDecodeError) =>
+    "success"
+
+primitive \nodoc\ _AlwaysFailDecoder is JsonDecoder[String]
+  fun apply(value: json.JsonValue): (String | JsonDecodeError) =>
+    JsonDecodeError("always fails")
+
+// ---------------------------------------------------------------------------
+// Generators
+// ---------------------------------------------------------------------------
+
+primitive \nodoc\ _InvalidJsonGen
+  fun apply(): Generator[String] =>
+    Generators.ascii_printable(
+      where min = 0, max = 50
+    ).map[String]({(s) => "{{INVALID " + s})
+
+primitive \nodoc\ _ValidJsonGen
+  fun apply(): Generator[String] =>
+    Generators.one_of[String]([
+      "null"
+      "true"
+      "false"
+      "42"
+      "-1"
+      "3.14"
+      "\"hello\""
+      "[]"
+      "[1,2,3]"
+      "{}"
+      "{\"a\":1}"
+      "{\"a\":\"b\",\"c\":true}"
+    ])
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertyDecodeJsonParseErrorPropagation is Property1[String val]
+  """Invalid JSON always yields JsonParseError, never success or decode error."""
+  fun name(): String => "json_decoder/property/parse_error_propagation"
+
+  fun gen(): Generator[String val] => _InvalidJsonGen()
+
+  fun property(sample: String val, h: PropertyHelper) =>
+    let response = _MakeJsonResponse(sample)
+    match DecodeJson[String](response, _AlwaysSucceedDecoder)
+    | let s: String =>
+      h.fail("expected JsonParseError, got success: " + s)
+    | let err: json.JsonParseError => None
+    | let err: JsonDecodeError =>
+      h.fail("expected JsonParseError, got JsonDecodeError: " + err.string())
+    end
+
+class \nodoc\ iso _PropertyDecodeJsonDecodeErrorPropagation
+  is Property1[String val]
+  """Valid JSON with always-fail decoder yields JsonDecodeError."""
+  fun name(): String => "json_decoder/property/decode_error_propagation"
+
+  fun gen(): Generator[String val] => _ValidJsonGen()
+
+  fun property(sample: String val, h: PropertyHelper) =>
+    let response = _MakeJsonResponse(sample)
+    match DecodeJson[String](response, _AlwaysFailDecoder)
+    | let s: String =>
+      h.fail("expected JsonDecodeError, got success: " + s)
+    | let err: json.JsonParseError =>
+      h.fail("expected JsonDecodeError, got JsonParseError: " + err.string())
+    | let err: JsonDecodeError => None
+    end
+
+class \nodoc\ iso _PropertyDecodeJsonIdentityDecoder is Property1[String val]
+  """Valid JSON with always-succeed decoder yields success."""
+  fun name(): String => "json_decoder/property/identity_decoder"
+
+  fun gen(): Generator[String val] => _ValidJsonGen()
+
+  fun property(sample: String val, h: PropertyHelper) =>
+    let response = _MakeJsonResponse(sample)
+    match DecodeJson[String](response, _AlwaysSucceedDecoder)
+    | let s: String => None
+    | let err: json.JsonParseError =>
+      h.fail("expected success, got JsonParseError: " + err.string())
+    | let err: JsonDecodeError =>
+      h.fail("expected success, got JsonDecodeError: " + err.string())
+    end
+
+// ---------------------------------------------------------------------------
+// Example-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestJsonDecoderSuccessfulDecode is UnitTest
+  """Valid JSON matching the decoder schema decodes to the expected type."""
+  fun name(): String => "json_decoder/successful_decode"
+
+  fun apply(h: TestHelper) =>
+    let value = json.JsonObject
+      .update("id", I64(1))
+      .update("title", "test")
+    match _TodoDecoder(value)
+    | let todo: _Todo =>
+      h.assert_eq[I64](1, todo.id)
+      h.assert_eq[String val]("test", todo.title)
+    | let err: JsonDecodeError =>
+      h.fail("expected success: " + err.string())
+    end
+
+class \nodoc\ iso _TestJsonDecoderMissingField is UnitTest
+  """JSON missing a required field yields JsonDecodeError."""
+  fun name(): String => "json_decoder/missing_field"
+
+  fun apply(h: TestHelper) =>
+    let value = json.JsonObject
+      .update("id", I64(1))
+    match _TodoDecoder(value)
+    | let todo: _Todo =>
+      h.fail("expected JsonDecodeError for missing 'title'")
+    | let err: JsonDecodeError =>
+      h.assert_true(err.message.size() > 0, "error should have a message")
+    end
+
+class \nodoc\ iso _TestJsonDecoderWrongType is UnitTest
+  """JSON with a field of the wrong type yields JsonDecodeError."""
+  fun name(): String => "json_decoder/wrong_type"
+
+  fun apply(h: TestHelper) =>
+    let value = json.JsonObject
+      .update("id", "not_a_number")
+      .update("title", "test")
+    match _TodoDecoder(value)
+    | let todo: _Todo =>
+      h.fail("expected JsonDecodeError for wrong type on 'id'")
+    | let err: JsonDecodeError =>
+      h.assert_true(err.message.size() > 0, "error should have a message")
+    end
+
+class \nodoc\ iso _TestDecodeJsonValidJson is UnitTest
+  """Full pipeline: valid JSON response decodes to typed domain object."""
+  fun name(): String => "decode_json/valid_json"
+
+  fun apply(h: TestHelper) =>
+    let response = _MakeJsonResponse("{\"id\": 42, \"title\": \"hello\"}")
+    match DecodeJson[_Todo](response, _TodoDecoder)
+    | let todo: _Todo =>
+      h.assert_eq[I64](42, todo.id)
+      h.assert_eq[String val]("hello", todo.title)
+    | let err: json.JsonParseError =>
+      h.fail("expected success, got JsonParseError: " + err.string())
+    | let err: JsonDecodeError =>
+      h.fail("expected success, got JsonDecodeError: " + err.string())
+    end
+
+class \nodoc\ iso _TestDecodeJsonInvalidJson is UnitTest
+  """Non-JSON body yields JsonParseError through DecodeJson."""
+  fun name(): String => "decode_json/invalid_json"
+
+  fun apply(h: TestHelper) =>
+    let response = _MakeJsonResponse("not json {{")
+    match DecodeJson[_Todo](response, _TodoDecoder)
+    | let todo: _Todo =>
+      h.fail("expected JsonParseError")
+    | let err: json.JsonParseError =>
+      h.assert_true(err.message.size() > 0, "error should have a message")
+    | let err: JsonDecodeError =>
+      h.fail("expected JsonParseError, got JsonDecodeError: " + err.string())
+    end
+
+class \nodoc\ iso _TestDecodeJsonWrongStructure is UnitTest
+  """Valid JSON with wrong structure yields JsonDecodeError through DecodeJson."""
+  fun name(): String => "decode_json/wrong_structure"
+
+  fun apply(h: TestHelper) =>
+    let response = _MakeJsonResponse("[1, 2, 3]")
+    match DecodeJson[_Todo](response, _TodoDecoder)
+    | let todo: _Todo =>
+      h.fail("expected JsonDecodeError")
+    | let err: json.JsonParseError =>
+      h.fail("expected JsonDecodeError, got JsonParseError: " + err.string())
+    | let err: JsonDecodeError =>
+      h.assert_true(err.message.size() > 0, "error should have a message")
+    end
+
+class \nodoc\ iso _TestJsonDecodeErrorString is UnitTest
+  """`JsonDecodeError.string()` returns the error message."""
+  fun name(): String => "json_decode_error/string"
+
+  fun apply(h: TestHelper) =>
+    let err = JsonDecodeError("msg")
+    h.assert_eq[String val]("msg", err.string())

--- a/courier/courier.pony
+++ b/courier/courier.pony
@@ -66,6 +66,9 @@ For HTTPS, use `HTTPClientConnection.ssl()` instead of
 - `RequestOptions` — builder interface for all methods (headers, query, auth)
 - `RequestOptionsWithBody` — builder interface with body methods (POST, etc.)
 - `ResponseJson` — parse `HTTPResponse` body as JSON via json-ng
+- `JsonDecoder` — interface for typed JSON decoders
+- `JsonDecodeError` — decode failure with descriptive message
+- `DecodeJson` — parse and decode an HTTP response body in one step
 
 ## Design
 

--- a/courier/decode_json.pony
+++ b/courier/decode_json.pony
@@ -1,0 +1,48 @@
+use json = "json"
+
+primitive DecodeJson[A: Any val]
+  """
+  Parse and decode an HTTP response body as a typed domain object in one step.
+
+  Combines `ResponseJson` (JSON parsing) with a `JsonDecoder` (structural
+  decoding) into a single call. The three-way return type distinguishes
+  between success, parse failure, and decode failure:
+
+  - `A` — the response body was valid JSON and matched the decoder's expected
+    structure
+  - `JsonParseError` — the response body was not valid JSON syntax
+  - `JsonDecodeError` — the JSON was valid but didn't match the decoder's
+    expected structure (missing fields, wrong types, etc.)
+
+  ```pony
+  use "courier"
+  use json = "json"
+
+  // In on_response_complete():
+  match DecodeJson[User](response, UserDecoder)
+  | let user: User =>
+    env.out.print("Hello, " + user.name)
+  | let err: json.JsonParseError =>
+    env.out.print("Invalid JSON: " + err.string())
+  | let err: JsonDecodeError =>
+    env.out.print("Unexpected structure: " + err.string())
+  end
+  ```
+  """
+
+  fun apply(
+    response: HTTPResponse,
+    decoder: JsonDecoder[A])
+    : (A | json.JsonParseError | JsonDecodeError)
+  =>
+    """
+    Parse `response.body` as JSON, then decode with `decoder`.
+
+    Returns `JsonParseError` if the body isn't valid JSON, `JsonDecodeError` if
+    the JSON doesn't match the decoder's expected structure, or the decoded
+    value on success.
+    """
+    match ResponseJson(response)
+    | let value: json.JsonValue => decoder(value)
+    | let err: json.JsonParseError => err
+    end

--- a/courier/json_decode_error.pony
+++ b/courier/json_decode_error.pony
@@ -1,0 +1,20 @@
+class val JsonDecodeError is Stringable
+  """
+  A structural mismatch when decoding parsed JSON into a domain type.
+
+  `JsonDecodeError` is distinct from json-ng's `JsonParseError`:
+  `JsonParseError` means the response body was not valid JSON syntax, while
+  `JsonDecodeError` means the JSON was syntactically valid but its structure
+  doesn't match what the decoder expected — a missing field, a field with the
+  wrong type, or any other shape mismatch. The message should describe what was
+  expected versus what was found.
+  """
+  let message: String
+
+  new val create(message': String) =>
+    """Create a decode error with a descriptive message."""
+    message = message'
+
+  fun string(): String iso^ =>
+    """Return the error message."""
+    message.clone()

--- a/courier/json_decoder.pony
+++ b/courier/json_decoder.pony
@@ -1,0 +1,34 @@
+use json = "json"
+
+interface val JsonDecoder[A: Any val]
+  """
+  Interface for converting a parsed `JsonValue` into a typed domain object.
+
+  Implement this interface to define how a specific JSON structure maps to your
+  application type. Return `JsonDecodeError` when the JSON doesn't match the
+  expected structure.
+
+  ```pony
+  use "courier"
+  use json = "json"
+
+  class val User
+    let name: String
+    let age: I64
+
+    new val create(name': String, age': I64) =>
+      name = name'
+      age = age'
+
+  primitive UserDecoder is JsonDecoder[User]
+    fun apply(value: json.JsonValue): (User | JsonDecodeError) =>
+      let nav = json.JsonNav(value)
+      try
+        User(nav("name").as_string()?, nav("age").as_i64()?)
+      else
+        JsonDecodeError("expected object with string 'name' and integer 'age'")
+      end
+  ```
+  """
+
+  fun apply(value: json.JsonValue): (A | JsonDecodeError)

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,4 +20,4 @@ Connects to `httpbin.org` over HTTPS and POSTs form-encoded data. Demonstrates `
 
 ## [json-api](json-api/)
 
-Connects to `jsonplaceholder.typicode.com` over HTTPS, fetches a JSON todo item, parses the response, and prints selected fields. Demonstrates `Request` builder for request construction, `ResponseCollector` for body accumulation, `ResponseJson` for JSON parsing, and `HTTPClientConnection.ssl()` for TLS connections.
+Connects to `jsonplaceholder.typicode.com` over HTTPS, fetches a JSON todo item, decodes the response into a typed `Todo` object, and prints selected fields. Demonstrates `Request` builder for request construction, `ResponseCollector` for body accumulation, `JsonDecoder` and `DecodeJson` for typed JSON decoding, and `HTTPClientConnection.ssl()` for TLS connections.

--- a/examples/json-api/main.pony
+++ b/examples/json-api/main.pony
@@ -4,6 +4,26 @@ use json = "json"
 use lori = "lori"
 use ssl = "ssl/net"
 
+class val Todo
+  """A todo item from jsonplaceholder.typicode.com."""
+  let title: String
+  let completed: Bool
+
+  new val create(title': String, completed': Bool) =>
+    title = title'
+    completed = completed'
+
+primitive TodoDecoder is JsonDecoder[Todo]
+  """Decode a JSON object into a `Todo`."""
+  fun apply(value: json.JsonValue): (Todo | JsonDecodeError) =>
+    let nav = json.JsonNav(value)
+    try
+      Todo(nav("title").as_string()?, nav("completed").as_bool()?)
+    else
+      JsonDecodeError(
+        "expected object with string 'title' and boolean 'completed'")
+    end
+
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPConnectAuth(env.root)
@@ -26,11 +46,12 @@ actor JsonApiClient is HTTPClientConnectionActor
 
   Usage: ./json-api
   Connects to jsonplaceholder.typicode.com over HTTPS, fetches a todo item,
-  parses the JSON response, and prints selected fields.
+  decodes the JSON response into a typed `Todo` object, and prints selected
+  fields.
 
   Demonstrates `Request` builder for request construction, `ResponseCollector`
-  for body accumulation, `ResponseJson` for JSON parsing, and
-  `HTTPClientConnection.ssl()` for TLS connections.
+  for body accumulation, `JsonDecoder` and `DecodeJson` for typed JSON
+  decoding, and `HTTPClientConnection.ssl()` for TLS connections.
   """
   var _http: HTTPClientConnection = HTTPClientConnection.none()
   var _collector: ResponseCollector = ResponseCollector
@@ -67,28 +88,15 @@ actor JsonApiClient is HTTPClientConnectionActor
   fun ref on_response_complete() =>
     try
       let response = _collector.build()?
-      match ResponseJson(response)
-      | let value: json.JsonValue =>
-        match value
-        | let obj: json.JsonObject =>
-          _out.print("Todo item:")
-          try
-            match obj("title")?
-            | let title: String =>
-              _out.print("  title: " + title)
-            end
-          end
-          try
-            match obj("completed")?
-            | let completed: Bool =>
-              _out.print("  completed: " + completed.string())
-            end
-          end
-        else
-          _out.print("Unexpected JSON type")
-        end
+      match DecodeJson[Todo](response, TodoDecoder)
+      | let todo: Todo =>
+        _out.print("Todo item:")
+        _out.print("  title: " + todo.title)
+        _out.print("  completed: " + todo.completed.string())
       | let err: json.JsonParseError =>
         _out.print("JSON parse error: " + err.string())
+      | let err: JsonDecodeError =>
+        _out.print("JSON decode error: " + err.string())
       end
     end
     _http.close()


### PR DESCRIPTION
Adds `JsonDecoder[A]`, `JsonDecodeError`, and `DecodeJson[A]` — three small types that complete the JSON pipeline from HTTP response to typed domain object.

- `JsonDecoder[A]` — `interface val` for converting `JsonValue` into a domain type
- `JsonDecodeError` — `class val` for structural mismatches (distinct from `JsonParseError`)
- `DecodeJson[A]` — primitive combining `ResponseJson` + decoder with three-way return type

The json-api example now uses `DecodeJson[Todo]` with a `TodoDecoder` instead of manual `ResponseJson` + `JsonNav` pattern matching.

Tests: 3 property-based (parse error propagation, decode error propagation, identity decoder) + 7 example-based (successful decode, missing field, wrong type, full pipeline valid/invalid/wrong structure, error stringability).

Design: #10