### PR TITLE
Add multipart/form-data support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Courier follows the same pattern as lori and stallion: protocol handler class ow
 **Request builder:**
 - `Request` — primitive factory with `get()`, `head()`, `post()`, `put()`, `patch()`, `delete()`, `options()`
 - `RequestOptions` — interface for all methods: `header()`, `query()`, `basic_auth()`, `bearer_auth()`, `build()`
-- `RequestOptionsWithBody` — extends with `body()`, `json_body()`, `form_body()`; narrows to `RequestOptions` after body is set
+- `RequestOptionsWithBody` — extends with `body()`, `json_body()`, `form_body()`, `multipart_body()`; narrows to `RequestOptions` after body is set
 - `_RequestBuilder` — internal class implementing both interfaces
 - GET/HEAD return `RequestOptions` (no body). DELETE/OPTIONS/POST/PUT/PATCH return `RequestOptionsWithBody`.
 - CONNECT and TRACE omitted from builder (use `HTTPRequest(CONNECT, ...)` directly)
@@ -71,6 +71,12 @@ Courier follows the same pattern as lori and stallion: protocol handler class ow
 - `QueryParams` — primitive, encodes `Array[(String, String)] val` as RFC 3986 query string (returns `String`)
 - `FormEncoder` — primitive, encodes as `application/x-www-form-urlencoded` per WHATWG (returns `Array[U8] val`)
 - `_PercentEncoder` — internal primitive with `query()` (RFC 3986) and `form()` (WHATWG) encoding modes
+
+**Multipart form data:**
+- `MultipartFormData` — `class ref` builder for `multipart/form-data` bodies. `field()` adds text fields, `file()` adds file attachments. `content_type()` returns the header value with boundary, `body()` serializes to wire format. Use with `multipart_body()` on the request builder.
+- `_MultipartField` — `class val`, internal text field part
+- `_MultipartFile` — `class val`, internal file attachment part
+- `_MultipartPart` — type alias `(_MultipartField | _MultipartFile)`
 
 **Auth helpers:**
 - `BasicAuth` — primitive, returns `("authorization", "Basic <base64>")` tuple

--- a/courier/_multipart_part.pony
+++ b/courier/_multipart_part.pony
@@ -1,0 +1,29 @@
+class val _MultipartField
+  """A text field in a multipart form."""
+  let name: String
+  let value: String
+
+  new val create(name': String, value': String) =>
+    name = name'
+    value = value'
+
+class val _MultipartFile
+  """A file attachment in a multipart form."""
+  let name: String
+  let filename: String
+  let content_type: String
+  let data: Array[U8] val
+
+  new val create(
+    name': String,
+    filename': String,
+    content_type': String,
+    data': Array[U8] val)
+  =>
+    name = name'
+    filename = filename'
+    content_type = content_type'
+    data = data'
+
+type _MultipartPart is (_MultipartField | _MultipartFile)
+  """A single part in a multipart form: either a text field or a file."""

--- a/courier/_request_builder.pony
+++ b/courier/_request_builder.pony
@@ -55,6 +55,11 @@ class ref _RequestBuilder
     _headers.set("Content-Type", "application/x-www-form-urlencoded")
     this
 
+  fun ref multipart_body(form: MultipartFormData): _RequestBuilder ref =>
+    _body = form.body()
+    _headers.set("Content-Type", form.content_type())
+    this
+
   fun ref build(): HTTPRequest val =>
     let full_path = _build_path()
     var hdrs: Headers iso = recover iso Headers end

--- a/courier/_test.pony
+++ b/courier/_test.pony
@@ -153,3 +153,16 @@ actor \nodoc\ Main is TestList
     test(_TestDecodeJsonInvalidJson)
     test(_TestDecodeJsonWrongStructure)
     test(_TestJsonDecodeErrorString)
+
+    // Multipart property-based tests
+    test(Property1UnitTest[USize](_PropertyMultipartBodyStructure))
+
+    // Multipart example-based tests
+    test(_TestMultipartBoundaryFormat)
+    test(_TestMultipartContentTypeBoundaryConsistency)
+    test(_TestMultipartTextField)
+    test(_TestMultipartFilePart)
+    test(_TestMultipartMixed)
+    test(_TestMultipartEmpty)
+    test(_TestMultipartBuilderIntegration)
+    test(_TestMultipartNonAsciiFilename)

--- a/courier/_test_multipart.pony
+++ b/courier/_test_multipart.pony
@@ -1,0 +1,289 @@
+use "pony_check"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertyMultipartBodyStructure
+  is Property1[USize]
+  """
+  For a form with N parts, the serialized body contains exactly N+1
+  boundary occurrences (N part boundaries + 1 closing boundary).
+  """
+  fun name(): String => "multipart/body_structure"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(0, 10)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    let form = MultipartFormData
+    var i: USize = 0
+    while i < arg1 do
+      if (i % 2) == 0 then
+        form.field("field" + i.string(), "value" + i.string())
+      else
+        let data: Array[U8] val = recover val
+          [as U8: 0xDE; 0xAD; 0xBE; 0xEF]
+        end
+        form.file("file" + i.string(), "f" + i.string() + ".bin",
+          "application/octet-stream", data)
+      end
+      i = i + 1
+    end
+
+    let body_str = String.from_array(form.body())
+    let ct = form.content_type()
+    let boundary_prefix = "multipart/form-data; boundary="
+    let boundary: String val = ct.substring(boundary_prefix.size().isize())
+
+    // Count boundary occurrences
+    let boundary_marker: String val = "--" + boundary
+    var count: USize = 0
+    var pos: ISize = 0
+    while true do
+      try
+        let p = body_str.find(boundary_marker where offset = pos)?
+        count = count + 1
+        pos = p + boundary_marker.size().isize()
+      else
+        break
+      end
+    end
+    // N parts means N opening boundaries + 1 closing boundary
+    ph.assert_eq[USize](arg1 + 1, count,
+      "should have N+1 boundary occurrences")
+
+    // Verify each field name appears in the body
+    i = 0
+    while i < arg1 do
+      if (i % 2) == 0 then
+        ph.assert_true(
+          body_str.contains("name=\"field" + i.string() + "\""),
+          "field name should appear in body")
+      else
+        ph.assert_true(
+          body_str.contains("name=\"file" + i.string() + "\""),
+          "file name should appear in body")
+        ph.assert_true(
+          body_str.contains("filename=\"f" + i.string() + ".bin\""),
+          "filename should appear in body")
+      end
+      i = i + 1
+    end
+
+// ---------------------------------------------------------------------------
+// Example-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestMultipartBoundaryFormat is UnitTest
+  """
+  The boundary in content_type() starts with "----courier" and has total
+  length 43 (11 prefix + 32 hex chars).
+  """
+  fun name(): String => "multipart/boundary_format"
+
+  fun apply(h: TestHelper) =>
+    let form = MultipartFormData
+    let ct = form.content_type()
+    let prefix = "multipart/form-data; boundary="
+    let ct_prefix: String val = ct.substring(0, prefix.size().isize())
+    h.assert_eq[String val](prefix, ct_prefix,
+      "content_type should start with media type and boundary param")
+    let boundary: String val = ct.substring(prefix.size().isize())
+    let boundary_prefix: String val = boundary.substring(0, 11)
+    h.assert_eq[String val]("----courier", boundary_prefix,
+      "boundary should start with ----courier")
+    h.assert_eq[USize](43, boundary.size(),
+      "boundary should be 11 prefix + 32 hex = 43 chars")
+    // Verify all hex chars after prefix
+    let hex_part: String val = boundary.substring(11)
+    for c in hex_part.values() do
+      h.assert_true(
+        ((c >= '0') and (c <= '9')) or ((c >= 'a') and (c <= 'f')),
+        "boundary suffix should be lowercase hex")
+    end
+
+class \nodoc\ iso _TestMultipartContentTypeBoundaryConsistency is UnitTest
+  """
+  The boundary string in content_type() matches what appears in body().
+  """
+  fun name(): String => "multipart/content_type_boundary_consistency"
+
+  fun apply(h: TestHelper) =>
+    let form = MultipartFormData
+    form.field("test", "value")
+
+    let ct = form.content_type()
+    let boundary_prefix = "multipart/form-data; boundary="
+    let boundary: String val = ct.substring(boundary_prefix.size().isize())
+
+    let body_str = String.from_array(form.body())
+    let opening: String val = "--" + boundary + "\r\n"
+    let closing: String val = "--" + boundary + "--\r\n"
+    h.assert_true(
+      body_str.contains(opening),
+      "body should contain opening boundary from content_type")
+    h.assert_true(
+      body_str.contains(closing),
+      "body should contain closing boundary from content_type")
+
+class \nodoc\ iso _TestMultipartTextField is UnitTest
+  """Single text field has correct Content-Disposition and body content."""
+  fun name(): String => "multipart/text_field"
+
+  fun apply(h: TestHelper) =>
+    let form = MultipartFormData
+    form.field("greeting", "hello world")
+    let body_str = String.from_array(form.body())
+
+    h.assert_true(
+      body_str.contains("Content-Disposition: form-data; name=\"greeting\""),
+      "should have Content-Disposition with field name")
+    // Text fields should NOT have a Content-Type header
+    h.assert_false(
+      body_str.contains("Content-Type:"),
+      "text field should not have Content-Type header")
+    h.assert_true(
+      body_str.contains("hello world"),
+      "body should contain field value")
+
+class \nodoc\ iso _TestMultipartFilePart is UnitTest
+  """
+  Single file has correct Content-Disposition with filename, Content-Type,
+  and binary data preserved.
+  """
+  fun name(): String => "multipart/file_part"
+
+  fun apply(h: TestHelper) =>
+    let data: Array[U8] val = recover val [as U8: 0x89; 0x50; 0x4E; 0x47] end
+    let form = MultipartFormData
+    form.file("avatar", "photo.png", "image/png", data)
+    let body = form.body()
+    let body_str = String.from_array(body)
+
+    h.assert_true(
+      body_str.contains(
+        "Content-Disposition: form-data;"
+        + " name=\"avatar\"; filename=\"photo.png\""),
+      "should have Content-Disposition with name and filename")
+    h.assert_true(
+      body_str.contains("Content-Type: image/png"),
+      "should have Content-Type header")
+
+    // Verify binary data is preserved byte-for-byte by searching for the
+    // 4-byte sequence in the raw body bytes
+    var found = false
+    var i: USize = 0
+    while i <= (body.size() - 4) do
+      try
+        if (body(i)? == 0x89) and (body(i + 1)? == 0x50)
+          and (body(i + 2)? == 0x4E) and (body(i + 3)? == 0x47)
+        then
+          found = true
+          break
+        end
+      end
+      i = i + 1
+    end
+    h.assert_true(found, "binary file data should be preserved byte-for-byte")
+
+class \nodoc\ iso _TestMultipartMixed is UnitTest
+  """Multiple fields and files in order with correct boundary delimiters."""
+  fun name(): String => "multipart/mixed"
+
+  fun apply(h: TestHelper) =>
+    let file_data: Array[U8] val = recover val [as U8: 1; 2; 3] end
+    let form = MultipartFormData
+      .> field("name", "alice")
+      .> file("doc", "readme.txt", "text/plain", file_data)
+      .> field("action", "upload")
+    let body_str = String.from_array(form.body())
+
+    // All three parts should be present
+    h.assert_true(
+      body_str.contains("name=\"name\""),
+      "first field should be present")
+    h.assert_true(
+      body_str.contains("name=\"doc\""),
+      "file should be present")
+    h.assert_true(
+      body_str.contains("name=\"action\""),
+      "second field should be present")
+
+    // Parts should appear in order
+    try
+      let name_pos = body_str.find("name=\"name\"")?
+      let doc_pos = body_str.find("name=\"doc\"")?
+      let action_pos = body_str.find("name=\"action\"")?
+      h.assert_true(name_pos < doc_pos, "name should come before doc")
+      h.assert_true(doc_pos < action_pos, "doc should come before action")
+    else
+      h.fail("all parts should be found")
+    end
+
+    // Closing boundary
+    let ct = form.content_type()
+    let boundary: String val = ct.substring(
+      "multipart/form-data; boundary=".size().isize())
+    let closing: String val = "--" + boundary + "--"
+    h.assert_true(
+      body_str.contains(closing),
+      "should end with closing boundary")
+
+class \nodoc\ iso _TestMultipartEmpty is UnitTest
+  """Empty form produces just closing boundary."""
+  fun name(): String => "multipart/empty"
+
+  fun apply(h: TestHelper) =>
+    let form = MultipartFormData
+    let body_str = String.from_array(form.body())
+    let ct = form.content_type()
+    let boundary: String val = ct.substring(
+      "multipart/form-data; boundary=".size().isize())
+
+    let expected: String val = "--" + boundary + "--\r\n"
+    h.assert_eq[String val](expected, body_str)
+
+class \nodoc\ iso _TestMultipartBuilderIntegration is UnitTest
+  """multipart_body() on request builder sets both body and Content-Type."""
+  fun name(): String => "multipart/builder_integration"
+
+  fun apply(h: TestHelper) =>
+    let form = MultipartFormData
+    form.field("key", "value")
+    let expected_ct = form.content_type()
+    let expected_body = form.body()
+
+    let req = Request.post("/upload")
+      .multipart_body(form)
+      .build()
+
+    // Content-Type header should match
+    h.assert_eq[String val](
+      expected_ct,
+      match req.headers.get("Content-Type")
+      | let v: String val => v
+      else ""
+      end)
+
+    // Body should match
+    match req.body
+    | let b: Array[U8] val =>
+      h.assert_eq[USize](expected_body.size(), b.size())
+    else
+      h.fail("body should be set")
+    end
+
+class \nodoc\ iso _TestMultipartNonAsciiFilename is UnitTest
+  """Raw UTF-8 filename is preserved in Content-Disposition."""
+  fun name(): String => "multipart/non_ascii_filename"
+
+  fun apply(h: TestHelper) =>
+    let data: Array[U8] val = recover val [as U8: 0xFF] end
+    let form = MultipartFormData
+    form.file("doc", "\xC3\xA9l\xC3\xA8ve.pdf", "application/pdf", data)
+    let body_str = String.from_array(form.body())
+    h.assert_true(
+      body_str.contains("filename=\"\xC3\xA9l\xC3\xA8ve.pdf\""),
+      "UTF-8 filename should be preserved as-is")

--- a/courier/courier.pony
+++ b/courier/courier.pony
@@ -65,6 +65,10 @@ For HTTPS, use `HTTPClientConnection.ssl()` instead of
 - `Request` — factory for typed step-builder request construction
 - `RequestOptions` — builder interface for all methods (headers, query, auth)
 - `RequestOptionsWithBody` — builder interface with body methods (POST, etc.)
+- `MultipartFormData` — `multipart/form-data` builder for file uploads and
+  mixed form submissions; use with `multipart_body()` on the request builder.
+  For simple key-value form data without files, use `FormEncoder`/`form_body()`
+  instead.
 - `ResponseJson` — parse `HTTPResponse` body as JSON via json-ng
 - `JsonDecoder` — interface for typed JSON decoders
 - `JsonDecodeError` — decode failure with descriptive message

--- a/courier/multipart_form_data.pony
+++ b/courier/multipart_form_data.pony
@@ -1,0 +1,102 @@
+use "format"
+use "random"
+use "time"
+
+class ref MultipartFormData
+  """
+  Build a `multipart/form-data` body for file uploads and mixed form
+  submissions (RFC 7578).
+
+  Use `field()` for plain text values and `file()` for file attachments.
+  After adding all parts, pass the builder to `multipart_body()` on the
+  request builder, which sets both the body and `Content-Type` header.
+
+  For simple key-value form data without files, use `FormEncoder` with
+  `form_body()` instead — it produces the more compact
+  `application/x-www-form-urlencoded` format.
+
+  ```pony
+  let form = MultipartFormData
+    .> field("username", "alice")
+    .> file("avatar", "photo.jpg", "image/jpeg", image_data)
+  let req = Request.post("/upload")
+    .multipart_body(form)
+    .build()
+  ```
+  """
+  let _boundary: String
+  embed _parts: Array[_MultipartPart]
+
+  new ref create() =>
+    """Create a new builder with a randomly generated boundary string."""
+    _parts = Array[_MultipartPart]
+    (let secs, let nanos) = Time.now()
+    let rand = Rand(secs.u64(), nanos.u64())
+    let a = rand.next()
+    let b = rand.next()
+    _boundary = "----courier"
+      + Format.int[U64](a, FormatHexSmallBare where width = 16, fill = '0')
+      + Format.int[U64](b, FormatHexSmallBare where width = 16, fill = '0')
+
+  fun ref field(name: String, value: String): MultipartFormData ref =>
+    """Add a text field to the form."""
+    _parts.push(_MultipartField(name, value))
+    this
+
+  fun ref file(
+    name: String,
+    filename: String,
+    file_content_type: String,
+    data: Array[U8] val)
+    : MultipartFormData ref
+  =>
+    """Add a file attachment to the form."""
+    _parts.push(_MultipartFile(name, filename, file_content_type, data))
+    this
+
+  fun content_type(): String =>
+    """
+    Return the `Content-Type` header value including the boundary parameter.
+
+    Pass this to the request's `Content-Type` header so the server knows how
+    to parse the body. The `multipart_body()` method on the request builder
+    does this automatically.
+    """
+    "multipart/form-data; boundary=" + _boundary
+
+  fun body(): Array[U8] val =>
+    """
+    Serialize all parts into the `multipart/form-data` wire format.
+
+    Each part is delimited by the boundary string. Field parts include a
+    `Content-Disposition` header; file parts additionally include a `filename`
+    parameter and a `Content-Type` header. The body ends with a closing
+    boundary.
+    """
+    let buf = recover iso Array[U8] end
+    for part in _parts.values() do
+      buf.append("--")
+      buf.append(_boundary)
+      buf.append("\r\n")
+      match part
+      | let f: _MultipartField val =>
+        buf.append("Content-Disposition: form-data; name=\"")
+        buf.append(f.name)
+        buf.append("\"\r\n\r\n")
+        buf.append(f.value)
+      | let f: _MultipartFile val =>
+        buf.append("Content-Disposition: form-data; name=\"")
+        buf.append(f.name)
+        buf.append("\"; filename=\"")
+        buf.append(f.filename)
+        buf.append("\"\r\nContent-Type: ")
+        buf.append(f.content_type)
+        buf.append("\r\n\r\n")
+        buf.append(f.data)
+      end
+      buf.append("\r\n")
+    end
+    buf.append("--")
+    buf.append(_boundary)
+    buf.append("--\r\n")
+    consume buf

--- a/courier/request.pony
+++ b/courier/request.pony
@@ -36,6 +36,14 @@ primitive Request
   let req = Request.post("/login")
     .form_body(recover val [("user", "alice"); ("pass", "secret")] end)
     .build()
+
+  // POST with multipart form data
+  let form = MultipartFormData
+    .> field("username", "alice")
+    .> file("avatar", "photo.jpg", "image/jpeg", image_data)
+  let req = Request.post("/upload")
+    .multipart_body(form)
+    .build()
   ```
   """
 

--- a/courier/request_options_with_body.pony
+++ b/courier/request_options_with_body.pony
@@ -40,5 +40,12 @@ interface ref RequestOptionsWithBody
     `Content-Type: application/x-www-form-urlencoded`.
     """
 
+  fun ref multipart_body(form: MultipartFormData): RequestOptions ref
+    """
+    Set the request body from a `MultipartFormData` builder.
+
+    Sets `Content-Type` to `multipart/form-data` with the boundary.
+    """
+
   fun ref build(): HTTPRequest val
     """Build the final `HTTPRequest val`."""

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,10 @@ Connects to `httpbin.org` over HTTPS and sends a GET request with a Bearer token
 
 Connects to `httpbin.org` over HTTPS and POSTs form-encoded data. Demonstrates `Request.post()` with `.form_body()` for `application/x-www-form-urlencoded` POST requests. httpbin.org echoes the submitted form fields back in a JSON response.
 
+## [multipart-upload](multipart-upload/)
+
+Connects to `httpbin.org` over HTTPS and POSTs a multipart form with a text field and a file attachment. Demonstrates `MultipartFormData` with `Request.post().multipart_body()` for `multipart/form-data` uploads. httpbin.org echoes the submitted form data and files back in a JSON response.
+
 ## [json-api](json-api/)
 
 Connects to `jsonplaceholder.typicode.com` over HTTPS, fetches a JSON todo item, decodes the response into a typed `Todo` object, and prints selected fields. Demonstrates `Request` builder for request construction, `ResponseCollector` for body accumulation, `JsonDecoder` and `DecodeJson` for typed JSON decoding, and `HTTPClientConnection.ssl()` for TLS connections.

--- a/examples/multipart-upload/main.pony
+++ b/examples/multipart-upload/main.pony
@@ -1,0 +1,80 @@
+use "../../courier"
+use "files"
+use lori = "lori"
+use ssl = "ssl/net"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPConnectAuth(env.root)
+    try
+      let ssl_ctx = recover val
+        let ctx = ssl.SSLContext
+        ctx.set_client_verify(true)
+        ctx.set_authority(
+          FilePath(FileAuth(env.root), "/etc/ssl/certs/ca-certificates.crt"))?
+        ctx
+      end
+      MultipartUploadClient(auth, ssl_ctx, env.out)
+    else
+      env.out.print("Failed to initialize SSL context")
+    end
+
+actor MultipartUploadClient is HTTPClientConnectionActor
+  """
+  HTTP client that POSTs multipart form data and prints the response.
+
+  Usage: ./multipart-upload
+  Connects to httpbin.org over HTTPS and POSTs a multipart form with a text
+  field and a file attachment. httpbin.org echoes the submitted form data
+  back in a JSON response.
+
+  Demonstrates `MultipartFormData` with `Request.post().multipart_body()`.
+  """
+  var _http: HTTPClientConnection = HTTPClientConnection.none()
+  var _collector: ResponseCollector = ResponseCollector
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPConnectAuth,
+    ssl_ctx: ssl.SSLContext val,
+    out: OutStream)
+  =>
+    _out = out
+    _http = HTTPClientConnection.ssl(auth, ssl_ctx,
+      "httpbin.org", "443", this, ClientConnectionConfig)
+
+  fun ref _http_client_connection(): HTTPClientConnection => _http
+
+  fun ref on_connected() =>
+    let file_data: Array[U8] val = recover val
+      "Hello from Pony!\n".array()
+    end
+    let form = MultipartFormData
+      .> field("username", "alice")
+      .> file("document", "hello.txt", "text/plain", file_data)
+    let req = Request.post("/post")
+      .multipart_body(form)
+      .header("Accept", "application/json")
+      .build()
+    _http.send_request(req)
+
+  fun ref on_connection_failure() =>
+    _out.print("Connection failed")
+
+  fun ref on_response(response: Response val) =>
+    _collector = ResponseCollector
+    _collector.set_response(response)
+    _out.print("< " + response.status.string() + " " + response.reason)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _collector.add_chunk(data)
+
+  fun ref on_response_complete() =>
+    try
+      let response = _collector.build()?
+      _out.print(String.from_array(response.body))
+    end
+    _http.close()
+
+  fun ref on_closed() =>
+    _out.print("Connection closed")


### PR DESCRIPTION
Adds `MultipartFormData` builder for file uploads and mixed form submissions (RFC 7578). Integrates with the request builder via `multipart_body()` on `RequestOptionsWithBody`, following the same pattern as `json_body()` and `form_body()`.

New types:
- `MultipartFormData` — builder class with `field()` for text values and `file()` for file attachments
- `_MultipartField` / `_MultipartFile` / `_MultipartPart` — internal part types

The builder generates a random boundary from `Time.now()`-seeded PRNG, serializes parts into the RFC 7578 wire format, and provides `content_type()` / `body()` for use with the request builder.

Also adds a `multipart-upload` example demonstrating the new API against httpbin.org.

Design: #8