### PR TITLE
Update lori to 0.14.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,22 @@
+
+## Fix potential connection hang when timer event subscription fails
+
+On some platforms, if the operating system cannot allocate resources for a connection timer (e.g., ENOMEM on kqueue or epoll), connections could hang silently instead of reporting an error. Timer subscription failures are now detected and reported as connection failures.
+
+## Add ConnectionFailedTimerError to ConnectionFailureReason
+
+`ConnectionFailureReason` now includes `ConnectionFailedTimerError`, which is reported when the connect timer's ASIO event subscription fails. If you match exhaustively on `ConnectionFailureReason`, you'll need to add a handler for the new variant:
+
+```pony
+match reason
+| ConnectionFailedDNS => ...
+| ConnectionFailedTCP => ...
+| ConnectionFailedSSL => ...
+| ConnectionFailedTimeout => ...
+| ConnectionFailedTimerError => ...
+end
+```
+
+## Require ponyc 0.63.1 or later
+
+courier now requires ponyc 0.63.1 or later. Older ponyc versions are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix potential connection hang when timer event subscription fails ([PR #48](https://github.com/ponylang/courier/pull/48))
 
 ### Added
 
 
 ### Changed
 
+- Add ConnectionFailedTimerError to ConnectionFailureReason ([PR #48](https://github.com/ponylang/courier/pull/48))
+- Require ponyc 0.63.1 or later ([PR #48](https://github.com/ponylang/courier/pull/48))
 
 ## [0.1.5] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ courier is beta quality software that will change frequently. Expect breaking ch
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/courier.git --version 0.1.5`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.13.1"
+      "version": "0.14.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/courier/_connection_failure_reason.pony
+++ b/courier/_connection_failure_reason.pony
@@ -23,3 +23,9 @@ primitive ConnectionFailedTimeout is _ConnectionFailureReason
   Connection attempt timed out before completing.
   """
   fun string(): String iso^ => "ConnectionFailedTimeout".clone()
+
+primitive ConnectionFailedTimerError is _ConnectionFailureReason
+  """
+  Connect timer ASIO event subscription failed.
+  """
+  fun string(): String iso^ => "ConnectionFailedTimerError".clone()

--- a/courier/connection_failure_reason.pony
+++ b/courier/connection_failure_reason.pony
@@ -2,7 +2,8 @@ type ConnectionFailureReason is
   ( ConnectionFailedDNS
   | ConnectionFailedTCP
   | ConnectionFailedSSL
-  | ConnectionFailedTimeout )
+  | ConnectionFailedTimeout
+  | ConnectionFailedTimerError )
   """
   Reason a connection attempt failed, delivered via `on_connection_failure()`.
   """

--- a/courier/courier.pony
+++ b/courier/courier.pony
@@ -107,7 +107,7 @@ actor MyClient is HTTPClientConnectionActor
 - `SendRequestResult` — result of `send_request()` (success or error)
 - `ConnectionFailureReason` — reason a connection attempt failed
   (`ConnectionFailedDNS`, `ConnectionFailedTCP`, `ConnectionFailedSSL`,
-  `ConnectionFailedTimeout`)
+  `ConnectionFailedTimeout`, `ConnectionFailedTimerError`)
 - `lori.TimerToken` — opaque token for timer cancellation and matching
 - `lori.TimerDuration` — validated timer duration (use
   `lori.MakeTimerDuration(milliseconds)` to create)

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -233,6 +233,7 @@ class HTTPClientConnection is
       | lori.ConnectionFailedTCP => ConnectionFailedTCP
       | lori.ConnectionFailedSSL => ConnectionFailedSSL
       | lori.ConnectionFailedTimeout => ConnectionFailedTimeout
+      | lori.ConnectionFailedTimerError => ConnectionFailedTimerError
       end
     match _lifecycle_event_receiver
     | let r: HTTPClientLifecycleEventReceiver ref =>

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -43,6 +43,7 @@ actor BasicClient is HTTPClientConnectionActor
     | ConnectionFailedTCP => _out.print("TCP connection failed")
     | ConnectionFailedSSL => _out.print("SSL handshake failed")
     | ConnectionFailedTimeout => _out.print("Connection timed out")
+    | ConnectionFailedTimerError => _out.print("Connect timer failed")
     end
 
   fun ref on_response(response: Response val) =>


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures, adds ConnectionFailedTimerError to ConnectionFailureReason, and requires ponyc 0.63.1 or later.