### PR TITLE
Add on_timer_failure callback

### DIFF
--- a/.release-notes/add-on-timer-failure-callback.md
+++ b/.release-notes/add-on-timer-failure-callback.md
@@ -1,0 +1,16 @@
+## Add on_timer_failure callback
+
+`HTTPClientLifecycleEventReceiver` has a new `on_timer_failure()` callback. It fires when a user timer created by `HTTPClientConnection.set_timer()` cannot be armed because its ASIO event subscription failed — typically from a kernel resource error like `ENOMEM` on `kevent` or `epoll_ctl`. Previously, the timer was silently cancelled and applications had no way to learn it had failed.
+
+Before the callback fires, the timer has already been cancelled and its token cleared. The connection itself continues running. The application decides how to recover — call `set_timer()` again to try a new timer, close the connection, or take some other action.
+
+```pony
+actor MyClient is HTTPClientConnectionActor
+  // ...
+
+  fun ref on_timer_failure() =>
+    // The query timer never armed. Give up on this request.
+    _http.close()
+```
+
+The callback has a default no-op implementation, so existing receivers keep the silent-cancel behavior until they override it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The `ssl` option is required because this library depends on the `ssl` package v
 
 ## Dependencies
 
-- [lori](https://github.com/ponylang/lori) 0.13.1 — TCP I/O with connection-actor model
+- [lori](https://github.com/ponylang/lori) 0.14.1 — TCP I/O with connection-actor model
 - [ssl](https://github.com/ponylang/ssl) 2.0.1 — SSL/TLS support
 
 ## Package

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.0"
+      "version": "0.14.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/courier/_connection_state.pony
+++ b/courier/_connection_state.pony
@@ -35,9 +35,19 @@ trait ref _ConnectionState
     Handle connection going idle.
     """
 
+  fun ref on_idle_timer_failure(client: HTTPClientConnection ref)
+    """
+    Handle idle timer ASIO subscription failure.
+    """
+
   fun ref on_timer(client: HTTPClientConnection ref, token: lori.TimerToken)
     """
     Handle one-shot timer firing.
+    """
+
+  fun ref on_timer_failure(client: HTTPClientConnection ref)
+    """
+    Handle user timer ASIO subscription failure.
     """
 
 class ref _Active is _ConnectionState
@@ -60,8 +70,14 @@ class ref _Active is _ConnectionState
   fun ref on_idle_timeout(client: HTTPClientConnection ref) =>
     client._handle_idle_timeout()
 
+  fun ref on_idle_timer_failure(client: HTTPClientConnection ref) =>
+    client._handle_idle_timer_failure()
+
   fun ref on_timer(client: HTTPClientConnection ref, token: lori.TimerToken) =>
     client._handle_timer(token)
+
+  fun ref on_timer_failure(client: HTTPClientConnection ref) =>
+    client._handle_timer_failure()
 
 class ref _Closed is _ConnectionState
   """
@@ -83,5 +99,11 @@ class ref _Closed is _ConnectionState
   fun ref on_idle_timeout(client: HTTPClientConnection ref) =>
     None
 
+  fun ref on_idle_timer_failure(client: HTTPClientConnection ref) =>
+    None
+
   fun ref on_timer(client: HTTPClientConnection ref, token: lori.TimerToken) =>
+    None
+
+  fun ref on_timer_failure(client: HTTPClientConnection ref) =>
     None

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -202,6 +202,11 @@ class HTTPClientConnection is
     Use `lori.MakeTimerDuration(milliseconds)` to create the duration value.
     `MakeTimerDuration` returns `(TimerDuration | ValidationFailure)`, so
     match on the result before passing it here.
+
+    Arming the timer can also fail asynchronously if the runtime cannot
+    register the underlying ASIO event (e.g. `ENOMEM` from `kevent` or
+    `epoll_ctl`). In that case `on_timer_failure()` is delivered instead of
+    `on_timer()`.
     """
     _tcp_connection.set_timer(duration)
 
@@ -255,8 +260,14 @@ class HTTPClientConnection is
   fun ref _on_idle_timeout() =>
     _state.on_idle_timeout(this)
 
+  fun ref _on_idle_timer_failure() =>
+    _state.on_idle_timer_failure(this)
+
   fun ref _on_timer(token: lori.TimerToken) =>
     _state.on_timer(this, token)
+
+  fun ref _on_timer_failure() =>
+    _state.on_timer_failure(this)
 
   //
   // _ResponseParserNotify — forwarding parser events to receiver
@@ -344,12 +355,36 @@ class HTTPClientConnection is
     """
     _close_connection()
 
+  fun ref _handle_idle_timer_failure() =>
+    """
+    Re-arm the idle timer after an ASIO subscription failure.
+
+    The idle timer is a courier-internal concern — users configure it via
+    `ClientConnectionConfig.idle_timeout` but never interact with it
+    directly. A silent re-arm preserves idle protection without surfacing
+    a failure users have no way to act on.
+    """
+    match \exhaustive\ _config
+    | let c: ClientConnectionConfig =>
+      _tcp_connection.idle_timeout(c.idle_timeout)
+    | None => _Unreachable()
+    end
+
   fun ref _handle_timer(token: lori.TimerToken) =>
     """
     Forward one-shot timer firing to the receiver.
     """
     match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPClientLifecycleEventReceiver ref => r.on_timer(token)
+    | None => _Unreachable()
+    end
+
+  fun ref _handle_timer_failure() =>
+    """
+    Forward user timer ASIO subscription failure to the receiver.
+    """
+    match \exhaustive\ _lifecycle_event_receiver
+    | let r: HTTPClientLifecycleEventReceiver ref => r.on_timer_failure()
     | None => _Unreachable()
     end
 

--- a/courier/http_client_lifecycle_event_receiver.pony
+++ b/courier/http_client_lifecycle_event_receiver.pony
@@ -112,3 +112,25 @@ trait ref HTTPClientLifecycleEventReceiver
     activity.
     """
     None
+
+  fun ref on_timer_failure() =>
+    """
+    Called when a user timer's ASIO event subscription fails. This is
+    typically caused by the kernel returning an error (e.g. `ENOMEM`) from
+    `kevent` or `epoll_ctl` when the runtime tries to register the timer.
+
+    Before this callback fires, the timer has already been cancelled in the
+    connection. Any `TimerToken` you stored from the `set_timer()` call is
+    now stale and can be discarded. The connection itself is unaffected and
+    continues running. The application decides how to recover — for example,
+    call `set_timer()` again from within this callback to create a new timer,
+    or `close()` the connection. A re-armed timer can itself fail
+    asynchronously under sustained pressure; if the new subscription also
+    fails, `on_timer_failure()` fires again.
+
+    Fires only for timers created via `HTTPClientConnection.set_timer()`.
+    Idle-timeout timer subscription failures are handled internally — the
+    library re-arms the idle timer automatically — and do not surface
+    through this or any other callback.
+    """
+    None


### PR DESCRIPTION
Bumps lori to 0.14.1 and wires up its new ASIO timer subscription failure callbacks. Idle-timer failures are handled internally — courier silently re-arms the idle timer — since users don't interact with that timer directly. User-timer failures are exposed via a new `on_timer_failure()` on `HTTPClientLifecycleEventReceiver`, since user timers are part of the public API and only the caller knows how to recover.