### PR TITLE
Fix response never arriving after sending a large request

### DIFF
--- a/.release-notes/fix-silent-connection-after-large-request.md
+++ b/.release-notes/fix-silent-connection-after-large-request.md
@@ -1,0 +1,3 @@
+## Fix response never arriving after sending a large request
+
+After sending a large request, a connection could stop receiving the server's response — the response would never arrive and the request would hang indefinitely. No error was raised and the connection was not closed; it simply went quiet, even though the server had already replied. This most often showed up on connections that pushed a large request body, such as uploads. Responses now arrive as expected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `ssl` option is required because this library depends on the `ssl` package v
 
 ## Dependencies
 
-- [lori](https://github.com/ponylang/lori) 0.15.0 — TCP I/O with connection-actor model
+- [lori](https://github.com/ponylang/lori) 0.15.1 — TCP I/O with connection-actor model
 - [ssl](https://github.com/ponylang/ssl) 2.0.1 — SSL/TLS support
 
 ## Package

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.0"
+      "version": "0.15.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.15.1, which fixes a connection that could go silent after a large request drained under backpressure, leaving the server's response undelivered.