### PR TITLE
Drop support for Windows 10

### DIFF
--- a/.release-notes/drop-windows-10-support.md
+++ b/.release-notes/drop-windows-10-support.md
@@ -1,0 +1,5 @@
+## Drop support for Windows 10
+
+Building courier for Windows now requires ponyc 0.66.0 or later and Windows 11 or Windows Server 2022 or later. Windows 10 is no longer supported. Non-Windows platforms are unaffected.
+
+On Windows, backpressure notifications (`on_throttled`/`on_unthrottled`) now fire based on whether the operating system can actually accept more data, matching the behavior on other platforms. Previously they could fire based on an internal heuristic that did not reflect the real state of the socket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `ssl` option is required because this library depends on the `ssl` package v
 
 ## Dependencies
 
-- [lori](https://github.com/ponylang/lori) 0.15.1 — TCP I/O with connection-actor model
+- [lori](https://github.com/ponylang/lori) 0.16.0 — TCP I/O with connection-actor model
 - [ssl](https://github.com/ponylang/ssl) 2.0.1 — SSL/TLS support
 
 ## Package

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.1"
+      "version": "0.16.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.16.0, which moves Windows networking from IOCP to readiness notifications.

On Windows this drops support for Windows 10 — the floor is now Windows 11 / Windows Server 2022 — and building for Windows now requires ponyc 0.66.0 or later. Backpressure notifications now reflect whether the OS can actually accept more data rather than an internal heuristic. Non-Windows platforms are unaffected.