### PR TITLE
Fix connections closed mid-transfer by the idle timeout

### DIFF
--- a/.release-notes/fix-idle-timeout-mid-transfer.md
+++ b/.release-notes/fix-idle-timeout-mid-transfer.md
@@ -1,0 +1,3 @@
+## Fix connections closed mid-transfer by the idle timeout
+
+A connection could be closed by its idle timeout while it was still actively transferring data to a slow peer. A large transfer draining slowly to a slow reader looked idle even though data was still moving, so it was closed mid-transfer. A connection is now closed by the idle timeout only when no data has moved in either direction for the timeout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `ssl` option is required because this library depends on the `ssl` package v
 
 ## Dependencies
 
-- [lori](https://github.com/ponylang/lori) 0.16.0 — TCP I/O with connection-actor model
+- [lori](https://github.com/ponylang/lori) 0.16.1 — TCP I/O with connection-actor model
 - [ssl](https://github.com/ponylang/ssl) 2.0.1 — SSL/TLS support
 
 ## Package

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.0"
+      "version": "0.16.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.16.1, which fixes the idle timer resetting on outgoing drains.

A connection could be closed by its idle timeout while still actively transferring data to a slow peer — the transfer looked idle even though bytes were still moving. A connection is now closed by the idle timeout only when no data has moved for the timeout.