### PR TITLE
Add opt-in redirect following

### DIFF
--- a/.release-notes/add-opt-in-redirect-following.md
+++ b/.release-notes/add-opt-in-redirect-following.md
@@ -1,0 +1,7 @@
+## Add opt-in redirect following
+
+Courier can now follow HTTP redirects transparently. Redirect following is off by default — wrap an `HTTPClientConnection` in a `RedirectFollower` to opt in.
+
+The follower sits in the callback path and handles redirect hops internally. The actor's response callbacks see only the final response; redirect responses and their bodies never reach user code. Same-origin redirects reuse the existing TCP connection. Cross-origin redirects use a `RedirectConnectionFactory` the actor provides to create a new one.
+
+Security rules are applied before any hop: an `https`-to-`http` downgrade is refused, and on a cross-origin hop the `Authorization`, `Cookie`, `Proxy-Authorization`, `Host`, and `Referer` headers are stripped. A redirect that cannot be followed — too many hops, `Location` missing or unparseable, or an insecure downgrade — arrives at `on_redirect_error` on `RedirectFollowerNotify`.

--- a/corral.json
+++ b/corral.json
@@ -18,6 +18,10 @@
     {
       "locator": "github.com/ponylang/ssl.git",
       "version": "4.0.0"
+    },
+    {
+      "locator": "github.com/ponylang/uri.git",
+      "version": "0.3.0"
     }
   ]
 }

--- a/courier/_redirect_decision.pony
+++ b/courier/_redirect_decision.pony
@@ -1,0 +1,145 @@
+use uri = "uri"
+
+primitive _NotARedirect
+  """
+  The response is not one courier follows: a non-redirect status, or a
+  redirect status courier does not act on (300, 304, 305). The response is
+  delivered normally through `on_response`.
+  """
+
+primitive _RedirectDecision
+  """
+  Decide what to do with a response on a redirect-following connection:
+  return a validated `Redirect` to follow, a `RedirectError` to refuse, or
+  `_NotARedirect` to deliver the response normally.
+
+  Pure: a function of the request that was sent, the origin it was sent to,
+  the response, and how many hops may still be followed. It applies the whole
+  redirect policy — which statuses redirect, `Location` resolution, the
+  `https`-to-`http` downgrade refusal, cross-origin credential stripping, and
+  method/body rewriting — with no socket, actor, or I/O.
+  """
+  fun apply(
+    sent: HTTPRequest val,
+    origin: Origin,
+    response: Response val,
+    max_redirects: USize)
+    : (Redirect | RedirectError | _NotARedirect)
+  =>
+    if not _is_redirect_status(response.status) then
+      return _NotARedirect
+    end
+
+    let location =
+      match \exhaustive\ response.headers.get("location")
+      | let l: String => l
+      | None => return MissingLocation
+      end
+
+    let target =
+      match \exhaustive\ _resolve_target(origin, sent.path, location)
+      | let p: ParsedURL val => p
+      | let e: RedirectError => return e
+      end
+
+    // Refuse an https -> http downgrade before anything else is built.
+    if origin.secure and (not target.is_ssl()) then
+      return InsecureRedirect
+    end
+
+    if max_redirects == 0 then
+      return TooManyRedirects
+    end
+
+    let cross_origin = not (origin == Origin._from_url(target))
+    (let new_method, let drop_body) = _rewrite(sent.method, response.status)
+    let new_headers = _rewrite_headers(sent.headers, cross_origin, drop_body)
+    let new_body: (Array[U8] val | None) =
+      if drop_body then None else sent.body end
+
+    Redirect._create(
+      response.status,
+      target,
+      HTTPRequest(new_method, target.request_path(), new_headers, new_body),
+      max_redirects - 1)
+
+  fun _is_redirect_status(status: U16): Bool =>
+    (status == 301) or (status == 302) or (status == 303)
+      or (status == 307) or (status == 308)
+
+  fun _resolve_target(
+    origin: Origin,
+    request_target: String val,
+    location: String val)
+    : (ParsedURL val | RedirectError)
+  =>
+    // Location is resolved against the request URL via ponylang/uri. A
+    // resolved scheme outside http/https (data:, file:, ...) fails URL.parse
+    // and becomes InvalidLocation.
+    let base_url: String val =
+      recover val
+        String
+          .> append(if origin.secure then "https" else "http" end)
+          .> append("://")
+          .> append(origin.host)
+          .> append(":")
+          .> append(origin.port)
+          .> append(request_target)
+      end
+    let base =
+      match \exhaustive\ uri.ParseURI(base_url)
+      | let u: uri.URI => u
+      | let _: uri.URIParseError => return InvalidLocation
+      end
+    let reference =
+      match \exhaustive\ uri.ParseURI(location)
+      | let u: uri.URI => u
+      | let _: uri.URIParseError => return InvalidLocation
+      end
+    let resolved =
+      match \exhaustive\ uri.ResolveURI(base, reference)
+      | let u: uri.URI => u
+      | let _: uri.ResolveURIError => return InvalidLocation
+      end
+    match \exhaustive\ URL.parse(resolved.string())
+    | let p: ParsedURL val => p
+    | let _: URLParseError => return InvalidLocation
+    end
+
+  fun _rewrite(method: Method, status: U16): (Method, Bool) =>
+    // 307/308 preserve method and body. 303 becomes GET (HEAD stays HEAD).
+    // 301/302 on POST become GET, matching long-standing client behavior;
+    // other methods are preserved.
+    match status
+    | 303 => if method is HEAD then (HEAD, false) else (GET, true) end
+    | 301 | 302 => if method is POST then (GET, true) else (method, false) end
+    else
+      (method, false)
+    end
+
+  fun _rewrite_headers(
+    headers: Headers val,
+    cross_origin: Bool,
+    drop_body: Bool)
+    : Headers val
+  =>
+    if (not cross_origin) and (not drop_body) then return headers end
+    recover val
+      let out = Headers
+      for (name, value) in headers.values() do
+        // Headers stores names lowercased, so these compare directly.
+        if cross_origin and _is_sensitive(name) then continue end
+        if drop_body and _is_body_header(name) then continue end
+        out.add(name, value)
+      end
+      out
+    end
+
+  fun _is_sensitive(name: String): Bool =>
+    (name == "authorization") or (name == "cookie")
+      or (name == "proxy-authorization") or (name == "host")
+      or (name == "referer")
+
+  fun _is_body_header(name: String): Bool =>
+    (name == "content-length") or (name == "content-type")
+      or (name == "content-encoding") or (name == "transfer-encoding")

--- a/courier/_test.pony
+++ b/courier/_test.pony
@@ -206,5 +206,40 @@ actor \nodoc\ Main is TestList
     test(_TestURLValidPort65535)
     test(_TestURLQueryWithoutPath)
 
+    // Redirect tests
+    test(_TestRedirectCrossOriginStripsCredentials)
+    test(_TestRedirectSameOriginKeepsCredentials)
+    test(_TestRedirectRefusesDowngrade)
+    test(_TestRedirectMissingLocation)
+    test(_TestRedirectLimitExhausted)
+    test(_TestRedirectRemainingDecrements)
+    test(_TestRedirect303PostBecomesGet)
+    test(_TestRedirect307PreservesMethodAndBody)
+    test(_TestRedirect301PostBecomesGet)
+    test(_TestRedirect302PostBecomesGet)
+    test(_TestRedirect308PreservesMethodAndBody)
+    test(_TestRedirectNonRedirectStatus)
+    test(_TestRedirectRelativeLocation)
+    test(_TestRedirectUnsupportedSchemeLocation)
+    test(Property1UnitTest[(U16, String val)](
+      _PropertyRedirectStripsCredentials))
+
+    // Redirect follower tests
+    test(_TestFollowerForwardsNonRedirect)
+    test(_TestFollowerForwardsNonRedirectWithLastRequest)
+    test(_TestFollowerInterceptsRedirect)
+    test(_TestFollowerRedirectErrorForwards)
+    test(_TestFollowerSuppressesBodyDuringRedirect)
+    test(_TestFollowerForwardsBodyWithoutRedirect)
+    test(_TestFollowerSuppressesClosedDuringRedirect)
+    test(_TestFollowerForwardsClosedWithoutRedirect)
+    test(_TestFollowerForwardsPassthroughCallbacks)
+    test(_TestFollowerConnectedForwardsWithoutPending)
+    test(_TestFollowerPendingRedirectSuppressesConnectedForward)
+    test(_TestFollowerSameOriginRedirectDoesNotUseFactory)
+    test(_TestFollowerCrossOriginRedirectSetsUpFactory)
+    test(_TestFollowerCompleteForwardsWithoutRedirect)
+    test(_TestFollowerErrorSuppressesBodyAndComplete)
+
     // Read loop tests
     test(_TestYieldReadOrdering)

--- a/courier/_test_parser.pony
+++ b/courier/_test_parser.pony
@@ -920,3 +920,4 @@ class \nodoc\ iso _TestMultiple1xx is UnitTest
     end
     h.assert_eq[String val](
       "Done", notify.collected_body_string())
+

--- a/courier/_test_redirect.pony
+++ b/courier/_test_redirect.pony
@@ -1,0 +1,396 @@
+use "pony_check"
+use "pony_test"
+
+primitive \nodoc\ _RedirectTestKit
+  fun response(status: U16, location: (String | None) = None): Response val =>
+    let headers =
+      recover val
+        let h = Headers
+        match location
+        | let l: String => h.set("location", l)
+        end
+        h
+      end
+    Response(HTTP11, status, "", headers)
+
+  fun request(
+    method: Method = GET,
+    path: String = "/dl/file",
+    headers: Headers val = recover val Headers end,
+    body: (Array[U8] val | None) = None)
+    : HTTPRequest val
+  =>
+    HTTPRequest(method, path, headers, body)
+
+  fun github_origin(): Origin =>
+    Origin(true, "github.com", "443")
+
+  fun decide(
+    sent: HTTPRequest val,
+    resp: Response val,
+    max_redirects: USize = 5)
+    : (Redirect | RedirectError | _NotARedirect)
+  =>
+    _RedirectDecision(sent, github_origin(), resp, max_redirects)
+
+class \nodoc\ iso _TestRedirectCrossOriginStripsCredentials is UnitTest
+  """
+  The GitHub download case: a 302 to a different host drops authorization,
+  cookie, proxy-authorization, host, and referer from the replayed request.
+  """
+  fun name(): String => "redirect/cross_origin_strips_credentials"
+
+  fun apply(h: TestHelper) =>
+    let sent =
+      _RedirectTestKit.request(
+        GET,
+        "/dl/file",
+        recover val
+          Headers
+            .> set("authorization", "Bearer secret")
+            .> set("cookie", "session=abc")
+            .> set("proxy-authorization", "Basic xyz")
+            .> set("host", "github.com")
+            .> set("referer", "https://github.com/dl/file")
+            .> set("user-agent", "ponyup")
+        end)
+    let response =
+      _RedirectTestKit.response(
+        302, "https://cdn.example.com/signed/file?sig=123")
+
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      let hdrs = r.request().headers
+      h.assert_true(
+        hdrs.get("authorization") is None,
+        "authorization must be stripped cross-origin")
+      h.assert_true(hdrs.get("cookie") is None, "cookie must be stripped")
+      h.assert_true(
+        hdrs.get("proxy-authorization") is None,
+        "proxy-authorization must be stripped")
+      h.assert_true(hdrs.get("host") is None, "host must be stripped")
+      h.assert_true(hdrs.get("referer") is None, "referer must be stripped")
+      match \exhaustive\ hdrs.get("user-agent")
+      | let v: String => h.assert_eq[String val]("ponyup", v)
+      | None => h.fail("user-agent must survive")
+      end
+      h.assert_eq[String val]("cdn.example.com", r.target().host)
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect, got _NotARedirect")
+    end
+
+class \nodoc\ iso _TestRedirectSameOriginKeepsCredentials is UnitTest
+  """A same-origin hop keeps authorization — only cross-origin strips it."""
+  fun name(): String => "redirect/same_origin_keeps_credentials"
+
+  fun apply(h: TestHelper) =>
+    let sent =
+      _RedirectTestKit.request(
+        GET,
+        "/old",
+        recover val Headers .> set("authorization", "Bearer secret") end)
+    let response = _RedirectTestKit.response(302, "https://github.com/new")
+
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      match \exhaustive\ r.request().headers.get("authorization")
+      | let v: String => h.assert_eq[String val]("Bearer secret", v)
+      | None => h.fail("authorization must survive a same-origin hop")
+      end
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirectRefusesDowngrade is UnitTest
+  """An https origin redirecting to http is refused."""
+  fun name(): String => "redirect/refuses_downgrade"
+
+  fun apply(h: TestHelper) =>
+    let response = _RedirectTestKit.response(302, "http://github.com/new")
+    match \exhaustive\ _RedirectTestKit.decide(
+      _RedirectTestKit.request(), response)
+    | InsecureRedirect => None
+    | let r: Redirect => h.fail("must refuse https->http, got Redirect")
+    | let _: RedirectError =>
+      h.fail("expected InsecureRedirect, got a different RedirectError")
+    | _NotARedirect => h.fail("expected InsecureRedirect")
+    end
+
+class \nodoc\ iso _TestRedirectMissingLocation is UnitTest
+  """A redirect status with no Location header is an error."""
+  fun name(): String => "redirect/missing_location"
+
+  fun apply(h: TestHelper) =>
+    match \exhaustive\ _RedirectTestKit.decide(
+      _RedirectTestKit.request(), _RedirectTestKit.response(302))
+    | MissingLocation => None
+    | let r: Redirect => h.fail("expected MissingLocation, got Redirect")
+    | let _: RedirectError =>
+      h.fail("expected MissingLocation, got a different RedirectError")
+    | _NotARedirect => h.fail("expected MissingLocation")
+    end
+
+class \nodoc\ iso _TestRedirectLimitExhausted is UnitTest
+  """A max of zero recognizes a redirect but refuses to follow it."""
+  fun name(): String => "redirect/limit_exhausted"
+
+  fun apply(h: TestHelper) =>
+    let response = _RedirectTestKit.response(302, "https://cdn.example.com/x")
+    match \exhaustive\ _RedirectTestKit.decide(
+      _RedirectTestKit.request(), response, 0)
+    | TooManyRedirects => None
+    | let r: Redirect => h.fail("max 0 must refuse, got Redirect")
+    | let _: RedirectError =>
+      h.fail("expected TooManyRedirects, got a different RedirectError")
+    | _NotARedirect => h.fail("expected TooManyRedirects")
+    end
+
+class \nodoc\ iso _TestRedirectRemainingDecrements is UnitTest
+  """A followed hop carries a count one smaller than the one that made it."""
+  fun name(): String => "redirect/remaining_decrements"
+
+  fun apply(h: TestHelper) =>
+    let response = _RedirectTestKit.response(302, "https://cdn.example.com/x")
+    match \exhaustive\ _RedirectTestKit.decide(
+      _RedirectTestKit.request(), response, 3)
+    | let r: Redirect => h.assert_eq[USize](2, r.remaining())
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirect303PostBecomesGet is UnitTest
+  """303 rewrites POST to GET and drops the body."""
+  fun name(): String => "redirect/303_post_becomes_get"
+
+  fun apply(h: TestHelper) =>
+    let sent =
+      _RedirectTestKit.request(
+        POST,
+        "/submit",
+        recover val
+          Headers
+            .> set("content-type", "application/json")
+            .> set("content-length", "2")
+            .> set("content-encoding", "gzip")
+            .> set("transfer-encoding", "chunked")
+        end,
+        recover val [as U8: '{'; '}'] end)
+    let response = _RedirectTestKit.response(303, "https://github.com/result")
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is GET, "303 must rewrite to GET")
+      h.assert_true(r.request().body is None, "303 must drop the body")
+      h.assert_true(
+        r.request().headers.get("content-type") is None,
+        "content-type must go with the body")
+      h.assert_true(
+        r.request().headers.get("content-length") is None,
+        "content-length must go with the body")
+      h.assert_true(
+        r.request().headers.get("content-encoding") is None,
+        "content-encoding must go with the body")
+      h.assert_true(
+        r.request().headers.get("transfer-encoding") is None,
+        "transfer-encoding must go with the body")
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirect307PreservesMethodAndBody is UnitTest
+  """307 preserves both the method and the body."""
+  fun name(): String => "redirect/307_preserves_method_and_body"
+
+  fun apply(h: TestHelper) =>
+    let body = recover val [as U8: 'h'; 'i'] end
+    let sent =
+      _RedirectTestKit.request(
+        POST,
+        "/submit",
+        recover val Headers .> set("content-length", "2") end,
+        body)
+    let response = _RedirectTestKit.response(307, "https://github.com/again")
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is POST, "307 must preserve POST")
+      match \exhaustive\ r.request().body
+      | let b: Array[U8] val => h.assert_eq[USize](2, b.size())
+      | None => h.fail("307 must preserve the body")
+      end
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirect301PostBecomesGet is UnitTest
+  """301 on POST becomes GET; 301 on GET stays GET."""
+  fun name(): String => "redirect/301_post_becomes_get"
+
+  fun apply(h: TestHelper) =>
+    let response = _RedirectTestKit.response(301, "https://github.com/q")
+
+    let post =
+      _RedirectTestKit.request(
+        POST, "/p", recover val Headers end, recover val [as U8: 'x'] end)
+    match _RedirectTestKit.decide(post, response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is GET, "301 POST must become GET")
+    else h.fail("expected Redirect for 301 POST")
+    end
+
+    match _RedirectTestKit.decide(_RedirectTestKit.request(GET, "/p"), response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is GET, "301 GET stays GET")
+    else h.fail("expected Redirect for 301 GET")
+    end
+
+class \nodoc\ iso _TestRedirect302PostBecomesGet is UnitTest
+  """302 on POST becomes GET; 302 on GET stays GET."""
+  fun name(): String => "redirect/302_post_becomes_get"
+
+  fun apply(h: TestHelper) =>
+    let response = _RedirectTestKit.response(302, "https://github.com/q")
+
+    let post =
+      _RedirectTestKit.request(
+        POST, "/p", recover val Headers end, recover val [as U8: 'x'] end)
+    match _RedirectTestKit.decide(post, response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is GET, "302 POST must become GET")
+    else h.fail("expected Redirect for 302 POST")
+    end
+
+    match _RedirectTestKit.decide(_RedirectTestKit.request(GET, "/p"), response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is GET, "302 GET stays GET")
+    else h.fail("expected Redirect for 302 GET")
+    end
+
+class \nodoc\ iso _TestRedirect308PreservesMethodAndBody is UnitTest
+  """308 preserves both the method and the body."""
+  fun name(): String => "redirect/308_preserves_method_and_body"
+
+  fun apply(h: TestHelper) =>
+    let body = recover val [as U8: 'h'; 'i'] end
+    let sent =
+      _RedirectTestKit.request(
+        POST,
+        "/submit",
+        recover val Headers .> set("content-length", "2") end,
+        body)
+    let response = _RedirectTestKit.response(308, "https://github.com/again")
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      h.assert_true(r.request().method is POST, "308 must preserve POST")
+      match \exhaustive\ r.request().body
+      | let b: Array[U8] val => h.assert_eq[USize](2, b.size())
+      | None => h.fail("308 must preserve the body")
+      end
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirectNonRedirectStatus is UnitTest
+  """A 200 is not a redirect. 304 and 305 are not followed either."""
+  fun name(): String => "redirect/non_redirect_status"
+
+  fun apply(h: TestHelper) =>
+    for status in [as U16: 200; 204; 304; 305].values() do
+      let response =
+        _RedirectTestKit.response(status, "https://github.com/x")
+      match _RedirectTestKit.decide(_RedirectTestKit.request(), response)
+      | _NotARedirect => None
+      else h.fail("status " + status.string() + " must be _NotARedirect")
+      end
+    end
+
+class \nodoc\ iso _TestRedirectRelativeLocation is UnitTest
+  """A relative Location resolves against the request base."""
+  fun name(): String => "redirect/relative_location"
+
+  fun apply(h: TestHelper) =>
+    let sent = _RedirectTestKit.request(GET, "/a/b/c")
+    let response = _RedirectTestKit.response(302, "../x")
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      h.assert_eq[String val]("github.com", r.target().host)
+      h.assert_eq[String val]("/a/x", r.target().path)
+    | let _: RedirectError => h.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect => h.fail("expected Redirect")
+    end
+
+class \nodoc\ iso _TestRedirectUnsupportedSchemeLocation is UnitTest
+  """
+  A Location carrying a scheme courier cannot follow is InvalidLocation, not
+  a same-origin path — it must not be reinterpreted as relative.
+  """
+  fun name(): String => "redirect/unsupported_scheme_location"
+
+  fun apply(h: TestHelper) =>
+    let locations =
+      [ "data:text/html,x"; "file:///etc/passwd"; "ftp://host/x"; "mailto:a@b" ]
+    for loc in locations.values() do
+      let response = _RedirectTestKit.response(302, loc)
+      match \exhaustive\ _RedirectTestKit.decide(
+        _RedirectTestKit.request(), response)
+      | InvalidLocation => None
+      | let r: Redirect =>
+        h.fail(
+          "must reject unfollowable scheme in " + loc
+            + ", got target host " + r.target().host)
+      | let _: RedirectError =>
+        h.fail(
+          "expected InvalidLocation for " + loc
+            + ", got a different RedirectError")
+      | _NotARedirect => h.fail("expected InvalidLocation for " + loc)
+      end
+    end
+
+class \nodoc\ iso _PropertyRedirectStripsCredentials
+  is Property1[(U16, String val)]
+  """
+  For every redirect status and any safe header, a cross-origin hop carrying
+  authorization, cookie, proxy-authorization, host, and referer drops all
+  five while keeping the safe header.
+  """
+  fun name(): String => "redirect/property_strips_credentials"
+
+  fun gen(): Generator[(U16, String val)] =>
+    Generators.zip2[U16, String val](
+      Generators.one_of[U16]([as U16: 301; 302; 303; 307; 308]),
+      Generators.ascii_letters(where min = 1, max = 12))
+
+  fun ref property(arg1: (U16, String val), ph: PropertyHelper) =>
+    (let status, let safe_name_raw) = arg1
+    // Keep the generated safe header clear of sensitive and body names.
+    let safe_name: String val = "x-" + safe_name_raw.lower()
+    let sent =
+      HTTPRequest(
+        GET,
+        "/dl",
+        recover val
+          Headers
+            .> set("authorization", "Bearer secret")
+            .> set("cookie", "s=1")
+            .> set("proxy-authorization", "Basic z")
+            .> set("host", "github.com")
+            .> set("referer", "https://github.com/dl")
+            .> set(safe_name, "keep")
+        end)
+    let response =
+      _RedirectTestKit.response(status, "https://cdn.example.com/x")
+
+    match \exhaustive\ _RedirectTestKit.decide(sent, response)
+    | let r: Redirect =>
+      let hdrs = r.request().headers
+      ph.assert_true(hdrs.get("authorization") is None)
+      ph.assert_true(hdrs.get("cookie") is None)
+      ph.assert_true(hdrs.get("proxy-authorization") is None)
+      ph.assert_true(hdrs.get("host") is None)
+      ph.assert_true(hdrs.get("referer") is None)
+      ph.assert_false(
+        hdrs.get(safe_name) is None,
+        "safe header " + safe_name + " must survive")
+    | let _: RedirectError =>
+      ph.fail("expected Redirect, got a RedirectError")
+    | _NotARedirect =>
+      ph.fail("expected Redirect for status " + status.string())
+    end

--- a/courier/_test_redirect_follower.pony
+++ b/courier/_test_redirect_follower.pony
@@ -1,0 +1,460 @@
+use lori = "lori"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class \nodoc\ _RecordingReceiver is RedirectFollowerNotify
+  """
+  Records which callbacks a RedirectFollower forwards so tests can verify
+  routing decisions.
+  """
+  var connected: USize = 0
+  var responses: USize = 0
+  embed response_list: Array[Response val] = Array[Response val]
+  var body_chunks: USize = 0
+  var completed: USize = 0
+  var closed: USize = 0
+  var redirect_errors: USize = 0
+  embed redirect_error_list: Array[RedirectError] = Array[RedirectError]
+  var connection_failures: USize = 0
+  var parse_errors: USize = 0
+  var throttled: USize = 0
+  var unthrottled: USize = 0
+  var timer_failures: USize = 0
+
+  fun ref on_connected() =>
+    connected = connected + 1
+
+  fun ref on_response(response: Response val) =>
+    responses = responses + 1
+    response_list.push(response)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    body_chunks = body_chunks + 1
+
+  fun ref on_response_complete() =>
+    completed = completed + 1
+
+  fun ref on_closed() =>
+    closed = closed + 1
+
+  fun ref on_redirect_error(err: RedirectError) =>
+    redirect_errors = redirect_errors + 1
+    redirect_error_list.push(err)
+
+  fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+    connection_failures = connection_failures + 1
+
+  fun ref on_parse_error(err: ParseError) =>
+    parse_errors = parse_errors + 1
+
+  fun ref on_throttled() =>
+    throttled = throttled + 1
+
+  fun ref on_unthrottled() =>
+    unthrottled = unthrottled + 1
+
+  fun ref on_timer_failure() =>
+    timer_failures = timer_failures + 1
+
+class \nodoc\ _CountingFactory is RedirectConnectionFactory
+  """
+  Counts how many times it was called and returns none() connections.
+  """
+  var calls: USize = 0
+
+  fun ref apply(target: ParsedURL val): HTTPClientConnection =>
+    calls = calls + 1
+    HTTPClientConnection.none()
+
+class \nodoc\ iso _TestFollowerForwardsNonRedirect is UnitTest
+  """
+  A non-redirect response forwards to the receiver when _last_request is None.
+  """
+  fun name(): String => "redirect_follower/forwards_non_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    let response = _RedirectTestKit.response(200)
+    follower.on_response(response)
+    h.assert_eq[USize](1, receiver.responses, "200 must forward")
+    h.assert_eq[USize](0, receiver.redirect_errors)
+
+class \nodoc\ iso _TestFollowerForwardsNonRedirectWithLastRequest is UnitTest
+  """
+  A non-redirect response forwards even when _last_request is set.
+  """
+  fun name(): String => "redirect_follower/forwards_non_redirect_with_request"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    let response = _RedirectTestKit.response(200)
+    follower.on_response(response)
+    h.assert_eq[USize](1, receiver.responses, "200 must forward")
+
+class \nodoc\ iso _TestFollowerInterceptsRedirect is UnitTest
+  """
+  A redirect response is intercepted — the receiver does not get on_response.
+  """
+  fun name(): String => "redirect_follower/intercepts_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+    h.assert_eq[USize](0, receiver.responses, "302 must not forward")
+    h.assert_eq[USize](0, receiver.redirect_errors)
+
+class \nodoc\ iso _TestFollowerRedirectErrorForwards is UnitTest
+  """
+  A redirect error (e.g. TooManyRedirects) calls on_redirect_error on the
+  receiver.
+  """
+  fun name(): String => "redirect_follower/redirect_error_forwards"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        0, // budget exhausted
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+    h.assert_eq[USize](
+      0, receiver.responses, "error must not forward response")
+    h.assert_eq[USize](
+      1, receiver.redirect_errors, "error must forward")
+
+class \nodoc\ iso _TestFollowerSuppressesBodyDuringRedirect is UnitTest
+  """
+  Body chunks arriving while a redirect is pending are silently consumed.
+  """
+  fun name(): String => "redirect_follower/suppresses_body_during_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Trigger a redirect to set _pending
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+
+    // Body chunks during a redirect are consumed silently
+    follower.on_body_chunk(recover val [as U8: 'x'] end)
+    follower.on_body_chunk(recover val [as U8: 'y'] end)
+    h.assert_eq[USize](0, receiver.body_chunks, "body must be suppressed")
+
+class \nodoc\ iso _TestFollowerForwardsBodyWithoutRedirect is UnitTest
+  """
+  Body chunks forward normally when no redirect is pending.
+  """
+  fun name(): String => "redirect_follower/forwards_body_without_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    follower.on_body_chunk(recover val [as U8: 'x'] end)
+    h.assert_eq[USize](1, receiver.body_chunks, "body must forward")
+
+class \nodoc\ iso _TestFollowerSuppressesClosedDuringRedirect is UnitTest
+  """
+  on_closed during a redirect teardown is suppressed.
+  """
+  fun name(): String => "redirect_follower/suppresses_closed_during_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Trigger a redirect to set _pending
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+
+    // on_closed while pending is suppressed
+    follower.on_closed()
+    h.assert_eq[USize](0, receiver.closed, "closed must be suppressed")
+
+class \nodoc\ iso _TestFollowerForwardsClosedWithoutRedirect is UnitTest
+  """
+  on_closed forwards when no redirect is pending.
+  """
+  fun name(): String => "redirect_follower/forwards_closed_without_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    follower.on_closed()
+    h.assert_eq[USize](1, receiver.closed, "closed must forward")
+
+class \nodoc\ iso _TestFollowerForwardsPassthroughCallbacks is UnitTest
+  """
+  Callbacks that always forward regardless of redirect state: connection
+  failure, parse error, throttled, unthrottled.
+  """
+  fun name(): String => "redirect_follower/forwards_passthrough_callbacks"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    follower.on_connection_failure(ConnectionFailedTCP)
+    h.assert_eq[USize](1, receiver.connection_failures)
+
+    follower.on_parse_error(TooLarge)
+    h.assert_eq[USize](1, receiver.parse_errors)
+
+    follower.on_throttled()
+    h.assert_eq[USize](1, receiver.throttled)
+
+    follower.on_unthrottled()
+    h.assert_eq[USize](1, receiver.unthrottled)
+
+    follower.on_timer_failure()
+    h.assert_eq[USize](1, receiver.timer_failures)
+
+class \nodoc\ iso _TestFollowerConnectedForwardsWithoutPending is UnitTest
+  """
+  on_connected without a pending redirect forwards to the receiver.
+  """
+  fun name(): String => "redirect_follower/connected_forwards_without_pending"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    follower.on_connected()
+    h.assert_eq[USize](1, receiver.connected, "connected must forward")
+
+class \nodoc\ iso _TestFollowerPendingRedirectSuppressesConnectedForward
+  is UnitTest
+  """
+  When a redirect is pending, on_response does not forward to the receiver.
+  The connected-with-pending path (which would send the redirect request)
+  requires a live connection and is covered by integration tests.
+  """
+  fun name(): String =>
+    "redirect_follower/pending_redirect_suppresses_connected_forward"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Trigger a cross-origin redirect — this sets _pending
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+    h.assert_eq[USize](
+      0, receiver.responses, "redirect must not forward response")
+
+class \nodoc\ iso _TestFollowerSameOriginRedirectDoesNotUseFactory is UnitTest
+  """
+  A same-origin redirect does not invoke the factory — the existing
+  connection is reused.
+  """
+  fun name(): String =>
+    "redirect_follower/same_origin_redirect_no_factory"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Same-origin redirect sets _pending
+    let response =
+      _RedirectTestKit.response(302, "https://github.com/other")
+    follower.on_response(response)
+    h.assert_eq[USize](
+      0, receiver.responses, "redirect must be intercepted")
+    h.assert_eq[USize](
+      0, factory.calls, "on_response must not invoke factory")
+
+class \nodoc\ iso _TestFollowerCrossOriginRedirectSetsUpFactory is UnitTest
+  """
+  A cross-origin redirect is intercepted and the factory is not called
+  until on_response_complete.
+  """
+  fun name(): String =>
+    "redirect_follower/cross_origin_redirect_sets_pending"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Cross-origin redirect is intercepted
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+    h.assert_eq[USize](
+      0, receiver.responses, "redirect must be intercepted")
+    h.assert_eq[USize](
+      0, factory.calls, "factory is not called until response completes")
+
+class \nodoc\ iso _TestFollowerCompleteForwardsWithoutRedirect is UnitTest
+  """
+  on_response_complete without a pending redirect forwards to the receiver.
+  """
+  fun name(): String =>
+    "redirect_follower/complete_forwards_without_redirect"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        5,
+        Origin(true, "example.com", "443"))
+
+    follower.on_response_complete()
+    h.assert_eq[USize](
+      1, receiver.completed, "complete must forward")
+
+class \nodoc\ iso _TestFollowerErrorSuppressesBodyAndComplete is UnitTest
+  """
+  After a redirect error, body chunks and on_response_complete from the
+  error response are suppressed — the receiver gets on_redirect_error
+  only.
+  """
+  fun name(): String =>
+    "redirect_follower/error_suppresses_body_and_complete"
+
+  fun apply(h: TestHelper) =>
+    let receiver: _RecordingReceiver ref = _RecordingReceiver
+    let factory: _CountingFactory ref = _CountingFactory
+    let follower =
+      RedirectFollower._for_test(
+        HTTPClientConnection.none(),
+        receiver,
+        factory,
+        0, // budget exhausted
+        Origin(true, "github.com", "443")
+        where last_request' = _RedirectTestKit.request())
+
+    // Trigger a redirect error (budget exhausted)
+    let response =
+      _RedirectTestKit.response(302, "https://cdn.example.com/file")
+    follower.on_response(response)
+    h.assert_eq[USize](
+      1, receiver.redirect_errors, "error must be delivered")
+
+    // Body chunks from the error response must be suppressed
+    follower.on_body_chunk(recover val [as U8: '<'; 'h'] end)
+    h.assert_eq[USize](
+      0, receiver.body_chunks, "body after error must be suppressed")
+
+    // on_response_complete from the error response must be suppressed
+    follower.on_response_complete()
+    h.assert_eq[USize](
+      0, receiver.completed, "complete after error must be suppressed")

--- a/courier/courier.pony
+++ b/courier/courier.pony
@@ -95,11 +95,33 @@ actor MyClient is HTTPClientConnectionActor
     end
 ```
 
+## Following Redirects
+
+Redirect following is opt-in via `RedirectFollower`, which wraps an
+`HTTPClientConnection` and intercepts redirect responses transparently. The
+actor's callback code has no redirect awareness — the follower handles hops
+internally and forwards only the final response.
+
+Same-origin redirects reuse the existing TCP connection. Cross-origin redirects
+use a `RedirectConnectionFactory` to create a new one.
+
+Implement `RedirectFollowerNotify` (which extends
+`HTTPClientLifecycleEventReceiver` with `on_redirect_error`), store a
+`RedirectFollower` instead of an `HTTPClientConnection`, and delegate
+`_http_client_connection()` to `_http.connection()`.
+
 ## Key Types
 
 - `HTTPClientConnectionActor` — trait for your actor
 - `HTTPClientConnection` — protocol handler class (stored as actor field)
 - `HTTPClientLifecycleEventReceiver` — callback trait (default no-ops)
+- `RedirectFollower` — wraps a connection and follows redirects transparently
+- `RedirectFollowerNotify` — callback trait for actors using RedirectFollower
+- `RedirectConnectionFactory` — creates connections for cross-origin redirects
+- `Redirect` — a validated redirect hop (internal to RedirectFollower)
+- `RedirectError` — why a redirect was not followed (`TooManyRedirects`,
+  `MissingLocation`, `InvalidLocation`, `InsecureRedirect`)
+- `Origin` — a URL's scheme, host, and port (the cross-origin boundary)
 - `HTTPRequest` — request data (method, path, headers, body)
 - `Response` — parsed response metadata (version, status, reason, headers)
 - `ClientConnectionConfig` — parser limits, idle timeout, connection timeout,

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -33,7 +33,7 @@ class HTTPClientConnection is
       _http = HTTPClientConnection(auth, host, port, this, config)
   ```
   """
-  let _lifecycle_event_receiver:
+  var _lifecycle_event_receiver:
     (HTTPClientLifecycleEventReceiver ref | None)
   let _config: (ClientConnectionConfig | None)
   let _host: String
@@ -123,6 +123,13 @@ class HTTPClientConnection is
     Return the underlying TCP connection.
     """
     _tcp_connection
+
+  fun ref _set_lifecycle_receiver(r: HTTPClientLifecycleEventReceiver ref) =>
+    """
+    Replace the lifecycle event receiver so callbacks route through a
+    different object.
+    """
+    _lifecycle_event_receiver = r
 
   fun ref send_request(request: HTTPRequest val): SendRequestResult =>
     """

--- a/courier/origin.pony
+++ b/courier/origin.pony
@@ -1,0 +1,35 @@
+class val Origin is (Equatable[Origin] & Stringable)
+  """
+  The origin of a URL: whether it is secure (https), the host, and the port.
+
+  Two requests share an origin when all three match. Host comparison is
+  case-insensitive; the host is lowercased on construction. Redirect header
+  stripping uses origin equality — credentials are removed when a hop crosses
+  to a different origin.
+  """
+  let secure: Bool
+  let host: String
+  let port: String
+
+  new val create(secure': Bool, host': String, port': String) =>
+    secure = secure'
+    host = host'.lower()
+    port = port'
+
+  new val _from_url(url: ParsedURL val) =>
+    secure = url.is_ssl()
+    host = url.host.lower()
+    port = url.port
+
+  fun eq(that: Origin box): Bool =>
+    (secure == that.secure) and (host == that.host) and (port == that.port)
+
+  fun string(): String iso^ =>
+    recover
+      String
+        .> append(if secure then "https" else "http" end)
+        .> append("://")
+        .> append(host)
+        .> append(":")
+        .> append(port)
+    end

--- a/courier/redirect.pony
+++ b/courier/redirect.pony
@@ -1,0 +1,55 @@
+class val Redirect
+  """
+  A validated redirect hop, ready to follow.
+
+  The `Location` header has been resolved against the request URL, security
+  rules applied (credentials stripped on a cross-origin hop, `https`-to-`http`
+  downgrade refused before a `Redirect` is ever built), and the method and
+  body rewritten for the response status. The remaining hop count is already
+  decremented for the next hop.
+
+  RedirectFollower uses this internally — application code does not interact
+  with it directly. The constructor is private so the security rules cannot
+  be bypassed and the remaining hop count cannot be reset.
+  """
+  let _status: U16
+  let _target: ParsedURL val
+  let _request: HTTPRequest val
+  let _remaining: USize
+
+  new val _create(
+    status': U16,
+    target': ParsedURL val,
+    request': HTTPRequest val,
+    remaining': USize)
+  =>
+    _status = status'
+    _target = target'
+    _request = request'
+    _remaining = remaining'
+
+  fun status(): U16 =>
+    """
+    The redirect status code (301, 302, 303, 307, or 308).
+    """
+    _status
+
+  fun target(): ParsedURL val =>
+    """
+    The resolved absolute URL to follow.
+    """
+    _target
+
+  fun request(): HTTPRequest val =>
+    """
+    The request to send on the next hop: the original request with its
+    method and body rewritten for the status and its headers stripped for a
+    cross-origin hop.
+    """
+    _request
+
+  fun remaining(): USize =>
+    """
+    How many redirect hops may still be followed after this one.
+    """
+    _remaining

--- a/courier/redirect_connection_factory.pony
+++ b/courier/redirect_connection_factory.pony
@@ -1,0 +1,10 @@
+interface ref RedirectConnectionFactory
+  """
+  Creates an HTTPClientConnection to a redirect target. Called by
+  RedirectFollower on cross-origin redirects — same-origin redirects reuse
+  the existing connection.
+  """
+  fun ref apply(target: ParsedURL val): HTTPClientConnection
+    """
+    Return a new connection to `target`.
+    """

--- a/courier/redirect_error.pony
+++ b/courier/redirect_error.pony
@@ -1,0 +1,31 @@
+primitive TooManyRedirects
+  """
+  The redirect budget was exhausted before the chain resolved to a
+  non-redirect response.
+  """
+
+primitive MissingLocation
+  """
+  A redirect response carried no `Location` header.
+  """
+
+primitive InvalidLocation
+  """
+  A redirect response's `Location` header did not resolve to a usable
+  `http` or `https` URL.
+  """
+
+primitive InsecureRedirect
+  """
+  A redirect would downgrade an `https` connection to `http`.
+  """
+
+type RedirectError is
+  ( TooManyRedirects
+  | MissingLocation
+  | InvalidLocation
+  | InsecureRedirect )
+  """
+  Why a redirect could not be followed, delivered via
+  `on_redirect_error()`. Each member documents its own case.
+  """

--- a/courier/redirect_follower.pony
+++ b/courier/redirect_follower.pony
@@ -1,0 +1,215 @@
+use lori = "lori"
+
+primitive _Suppressing
+
+class RedirectFollower is HTTPClientLifecycleEventReceiver
+  """
+  Follows HTTP redirects transparently by sitting in the callback path
+  between an HTTPClientConnection and the user's receiver.
+
+  The connection delivers callbacks to the follower; the follower handles
+  redirects internally and forwards only non-redirect events to the user.
+  The user's callback code sees only the final non-redirect response.
+
+  Same-origin redirects reuse the existing TCP connection. Cross-origin
+  redirects use a RedirectConnectionFactory to create a new one.
+
+  Use `none()` as the field default so that `this` is `ref` in the actor
+  constructor body, then replace with `create()`:
+
+  ```pony
+  actor MyClient is (HTTPClientConnectionActor & RedirectFollowerNotify)
+    var _http: RedirectFollower = RedirectFollower.none()
+
+    new create(auth: lori.TCPConnectAuth, ssl_ctx: ssl_net.SSLContext val,
+      host: String, port: String)
+    =>
+      let config = ClientConnectionConfig
+      let conn = HTTPClientConnection.ssl(
+        auth, ssl_ctx, host, port, this, config)
+      let factory =
+        {ref(target: ParsedURL val)
+          (auth, ssl_ctx, config, client = this)
+          : HTTPClientConnection
+        =>
+          if target.is_ssl() then
+            HTTPClientConnection.ssl(
+              auth, ssl_ctx, target.host, target.port, client, config)
+          else
+            HTTPClientConnection(
+              auth, target.host, target.port, client, config)
+          end
+        }
+      _http = RedirectFollower(conn, this, factory, 5,
+        Origin(true, host, port))
+
+    fun ref _http_client_connection(): HTTPClientConnection =>
+      _http.connection()
+  ```
+  """
+  var _conn: HTTPClientConnection
+  let _receiver: RedirectFollowerNotify ref
+  let _factory: RedirectConnectionFactory
+  var _remaining: USize
+  var _origin: Origin
+  var _last_request: (HTTPRequest val | None) = None
+  var _pending: (Redirect | _Suppressing | None) = None
+
+  new create(
+    conn: HTTPClientConnection,
+    receiver: RedirectFollowerNotify ref,
+    factory: RedirectConnectionFactory,
+    max_redirects: USize,
+    origin: Origin)
+  =>
+    """
+    Create a redirect follower that wraps `conn`.
+
+    Inserts itself into the connection's callback path so redirect responses
+    are handled internally. Non-redirect responses forward to `receiver`.
+    Cross-origin redirects use `factory` to create a new connection.
+    `max_redirects` is how many hops to follow before refusing with
+    TooManyRedirects. `origin` is the scheme, host, and port of the initial
+    connection — used to detect cross-origin hops.
+    """
+    _conn = conn
+    _receiver = receiver
+    _factory = factory
+    _remaining = max_redirects
+    _origin = origin
+    conn._set_lifecycle_receiver(this)
+
+  new _for_test(
+    conn': HTTPClientConnection,
+    receiver': RedirectFollowerNotify ref,
+    factory': RedirectConnectionFactory,
+    max_redirects': USize,
+    origin': Origin,
+    last_request': (HTTPRequest val | None) = None)
+  =>
+    """
+    Test constructor that accepts pre-set state without installing the
+    follower into a live connection.
+    """
+    _conn = conn'
+    _receiver = receiver'
+    _factory = factory'
+    _remaining = max_redirects'
+    _origin = origin'
+    _last_request = last_request'
+
+  new none() =>
+    """
+    Placeholder for the actor field default, replaced in the actor
+    constructor body where `this` is available as `ref`.
+    """
+    _conn = HTTPClientConnection.none()
+    _receiver = object ref is RedirectFollowerNotify end
+    _factory =
+      object ref is RedirectConnectionFactory
+        fun ref apply(target: ParsedURL val): HTTPClientConnection =>
+          HTTPClientConnection.none()
+      end
+    _remaining = 0
+    _origin = Origin(false, "", "")
+
+  fun ref connection(): HTTPClientConnection =>
+    """
+    The current underlying connection, which changes after a cross-origin
+    redirect.
+    """
+    _conn
+
+  fun ref send_request(request: HTTPRequest val): SendRequestResult =>
+    """
+    Send a request and remember it for redirect decisions.
+    """
+    _last_request = request
+    _conn.send_request(request)
+
+  //
+  // HTTPClientLifecycleEventReceiver — redirects are handled here;
+  // everything else forwards to _receiver.
+  //
+  fun ref on_connected() =>
+    match _pending = None
+    | let r: Redirect =>
+      _last_request = r.request()
+      match _conn.send_request(r.request())
+      | ResponsePending => _Unreachable()
+      | ConnectionClosed => None // OS send failure; on_closed already fired
+      end
+    else
+      _receiver.on_connected()
+    end
+
+  fun ref on_response(response: Response val) =>
+    match _last_request
+    | let sent: HTTPRequest val =>
+      match \exhaustive\ _RedirectDecision(
+        sent, _origin, response, _remaining)
+      | let r: Redirect =>
+        _pending = r
+        return
+      | let err: RedirectError =>
+        _pending = _Suppressing
+        _receiver.on_redirect_error(err)
+        return
+      | _NotARedirect => None
+      end
+    end
+    _receiver.on_response(response)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    if _pending is None then
+      _receiver.on_body_chunk(data)
+    end
+
+  fun ref on_response_complete() =>
+    match _pending = None
+    | _Suppressing => return
+    | let r: Redirect =>
+      let target_origin = Origin._from_url(r.target())
+      if _origin == target_origin then
+        _remaining = r.remaining()
+        _last_request = r.request()
+        match _conn.send_request(r.request())
+        | ResponsePending => _Unreachable()
+        | ConnectionClosed => None // OS send failure; on_closed already fired
+        end
+      else
+        _pending = r
+        _origin = target_origin
+        _remaining = r.remaining()
+        _conn.close()
+        _conn = _factory(r.target())
+        _conn._set_lifecycle_receiver(this)
+      end
+    else
+      _receiver.on_response_complete()
+    end
+
+  fun ref on_closed() =>
+    match _pending
+    | let _: Redirect => None
+    else
+      _receiver.on_closed()
+    end
+
+  fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+    _receiver.on_connection_failure(reason)
+
+  fun ref on_parse_error(err: ParseError) =>
+    _receiver.on_parse_error(err)
+
+  fun ref on_throttled() =>
+    _receiver.on_throttled()
+
+  fun ref on_unthrottled() =>
+    _receiver.on_unthrottled()
+
+  fun ref on_timer(token: lori.TimerToken) =>
+    _receiver.on_timer(token)
+
+  fun ref on_timer_failure() =>
+    _receiver.on_timer_failure()

--- a/courier/redirect_follower_notify.pony
+++ b/courier/redirect_follower_notify.pony
@@ -1,0 +1,14 @@
+trait ref RedirectFollowerNotify is HTTPClientLifecycleEventReceiver
+  """
+  Callback trait for actors using RedirectFollower.
+
+  Extends HTTPClientLifecycleEventReceiver with one callback for redirect
+  errors. Implement this instead of the base trait when using RedirectFollower.
+  """
+  fun ref on_redirect_error(err: RedirectError) =>
+    """
+    Called when a redirect cannot be followed: budget exhausted, Location
+    missing or unparseable, or https-to-http downgrade. The 3xx response is
+    not delivered through on_response.
+    """
+    None

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,10 @@ Connects to `httpbin.org` over HTTPS and POSTs a multipart form with a text fiel
 
 Connects to `jsonplaceholder.typicode.com` over HTTPS, fetches a JSON todo item, decodes the response into a typed `Todo` object, and prints selected fields. Demonstrates `Request` builder for request construction, `ResponseCollector` for body accumulation, `JSONDecoder` and `DecodeJSON` for typed JSON decoding, and `HTTPClientConnection.ssl()` for TLS connections.
 
+## [redirect](redirect/)
+
+Connects to `httpbin.org` over HTTPS and requests `/redirect/3`, which returns three chained 302 redirects before a final 200. The actor's callbacks see only the final response — `RedirectFollower` handles the hops internally. Demonstrates `RedirectFollower` wrapping an `HTTPClientConnection`, `RedirectFollowerNotify` for the `on_redirect_error` callback, `RedirectConnectionFactory` as a lambda for cross-origin hops, and `_http_client_connection()` delegating to `_http.connection()`.
+
 ## [response-timeout](response-timeout/)
 
 Connects to `httpbin.org` over HTTPS with a 3-second response deadline on a deliberately slow endpoint. The timer fires before the response arrives, demonstrating `HTTPClientConnection.set_timer()`, `HTTPClientConnection.cancel_timer()`, and `on_timer()` on `HTTPClientLifecycleEventReceiver` in a response deadline pattern.

--- a/examples/redirect/main.pony
+++ b/examples/redirect/main.pony
@@ -1,0 +1,109 @@
+use "../../courier"
+use "files"
+use lori = "lori"
+use ssl = "ssl/net"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPConnectAuth(env.root)
+    try
+      let ssl_ctx =
+        recover val
+          ssl.SSLContext
+            .> set_client_verify(true)
+            .> set_authority(
+              FilePath(
+                FileAuth(env.root),
+                "/etc/ssl/certs/ca-certificates.crt"))?
+        end
+      RedirectClient(auth, ssl_ctx, "httpbin.org", "443", env.out)
+    else
+      env.err.print("SSL context creation failed")
+    end
+
+actor RedirectClient is
+  (HTTPClientConnectionActor & RedirectFollowerNotify)
+  """
+  HTTP client that follows redirects transparently.
+
+  Usage: ./redirect
+  Connects to httpbin.org:443, sends GET /redirect/3, and prints the final
+  response after three redirect hops. Requires network access.
+
+  The actor's response callbacks see only the final 200 — redirect hops are
+  handled internally by RedirectFollower. The only redirect-specific callback
+  is on_redirect_error, which fires when a hop cannot be followed.
+  """
+  var _http: RedirectFollower = RedirectFollower.none()
+  var _collector: ResponseCollector = ResponseCollector
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPConnectAuth,
+    ssl_ctx: ssl.SSLContext val,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    let config = ClientConnectionConfig
+
+    let conn =
+      HTTPClientConnection.ssl(
+        auth, ssl_ctx, host, port, this, config)
+
+    let factory =
+      {ref(target: ParsedURL val)
+        (auth, ssl_ctx, config, client = this)
+        : HTTPClientConnection
+      =>
+        if target.is_ssl() then
+          HTTPClientConnection.ssl(
+            auth, ssl_ctx, target.host, target.port, client, config)
+        else
+          HTTPClientConnection(
+            auth, target.host, target.port, client, config)
+        end
+      }
+
+    _http =
+      RedirectFollower(
+        conn, this, factory, 5, Origin(true, host, port))
+
+  fun ref _http_client_connection(): HTTPClientConnection =>
+    _http.connection()
+
+  fun ref on_connected() =>
+    _http.send_request(Request.get("/redirect/3").build())
+
+  fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+    match \exhaustive\ reason
+    | ConnectionFailedDNS => _out.print("DNS resolution failed")
+    | ConnectionFailedTCP => _out.print("TCP connection failed")
+    | ConnectionFailedSSL => _out.print("SSL handshake failed")
+    | ConnectionFailedTimeout => _out.print("Connection timed out")
+    | ConnectionFailedTimerError => _out.print("Connect timer failed")
+    end
+
+  fun ref on_response(response: Response val) =>
+    _collector = ResponseCollector
+    _collector.set_response(response)
+    _out.print("< " + response.version.string() + " "
+      + response.status.string() + " " + response.reason)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _collector.add_chunk(data)
+
+  fun ref on_response_complete() =>
+    try
+      let response = _collector.build()?
+      _out.print(String.from_array(response.body))
+    end
+    _http.connection().close()
+
+  fun ref on_redirect_error(err: RedirectError) =>
+    _out.print("Redirect failed")
+    _http.connection().close()
+
+  fun ref on_closed() =>
+    _out.print("Connection closed")

--- a/examples/redirect/redirect.pony
+++ b/examples/redirect/redirect.pony
@@ -1,0 +1,12 @@
+"""
+Redirect following example.
+
+Connects to `httpbin.org` over HTTPS and requests `/redirect/3`, which returns
+three chained 302 redirects before a final 200. The actor's callbacks see only
+the final response — `RedirectFollower` handles the hops internally.
+
+Demonstrates `RedirectFollower` wrapping an `HTTPClientConnection`,
+`RedirectFollowerNotify` for the `on_redirect_error` callback,
+`RedirectConnectionFactory` as a lambda for cross-origin hops, and
+`_http_client_connection()` delegating to `_http.connection()`.
+"""


### PR DESCRIPTION
Redirect following is opt-in via `RedirectFollower`, a class that wraps an `HTTPClientConnection` and intercepts redirect responses. The actor's callbacks see only the final response — redirect hops are handled internally.

Same-origin redirects reuse the existing TCP connection. Cross-origin redirects use a `RedirectConnectionFactory` the actor provides to create a new one. Security rules applied before each hop: `https`-to-`http` downgrade refused, and `Authorization`/`Cookie`/`Proxy-Authorization`/`Host`/`Referer` headers stripped on cross-origin hops.

The follower is a composition layer — `HTTPClientConnection` gains one package-private method (`_set_lifecycle_receiver`) and remains redirect-unaware.
