### PR TITLE
Update lori to 0.17.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,39 @@
+## Fix a hang when closing a connection from a response callback
+
+Calling `close()` from inside `on_response()`, `on_body_chunk()`, or `on_response_complete()` could leave the connection attempting one more read on the socket it had just closed. When many connections are opening and closing, that read could block one of the runtime's scheduler threads and keep the program from exiting. A connection closed from one of those callbacks no longer makes that read.
+
+## Fix a connection stalling under sustained write backpressure
+
+courier stops reading a connection while it is under write backpressure, from `on_throttled()` until `on_unthrottled()`. Under sustained backpressure with the server still sending, that pause could become permanent: data stopped moving in both directions and the connection never recovered on its own, staying wedged until it was closed. This was most likely on a multi-threaded runtime. A connection under sustained write backpressure no longer stalls.
+
+## Fix backpressure not stopping incoming data on an HTTPS connection
+
+On an HTTPS connection, backpressure did not stop response data arriving. When the socket backs up, courier stops reading the connection and `on_throttled()` fires; on HTTPS everything already decrypted from the same socket read was delivered anyway, so `on_response()`, `on_body_chunk()`, and `on_response_complete()` still fired after `on_throttled()`. Reading now stops as soon as backpressure is applied. Nothing is lost: data already decrypted is held rather than dropped, and it is delivered when backpressure clears, ahead of anything read off the socket afterwards.
+
+## Fix yield_read() not taking effect on an HTTPS connection
+
+`yield_read()` stops reading so other actors get a turn; call it from `on_body_chunk()` to keep one large response from starving the rest of your program. On an HTTPS connection it did not stop reading when you called it: everything already decrypted from the same socket read was handed to you first, so a long run of chunks could arrive before anything else ran. The yield now takes effect as soon as the parser finishes the data it was working on when you called it, on an HTTPS connection as on a plain HTTP one. It is still not immediate on either: every remaining chunk in that data fires `on_body_chunk()` before reading stops.
+
+## Fix a hang when writing to a socket under load
+
+Under write load, sending on a connection could hang the whole program. When the socket send buffer filled on a blocking file descriptor, the write stalled and never returned. Connections use non-blocking descriptors, so reaching this took the operating system reusing a closed connection's descriptor number for a blocking socket elsewhere in the same process — rare, but possible. The hang is closed on Linux, FreeBSD, OpenBSD, and DragonFly. macOS and Windows are unchanged.
+
+## Require ponyc 0.67.0 or later
+
+courier now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.64.0, and 0.66.0 on Windows; 0.64.0 through 0.66.x are no longer supported. The write hang under load is closed by a socket call that ponyc added in 0.67.0.
+
+## Move to ponylang/ssl 3.0.0
+
+courier now depends on ponylang/ssl 3.0.0, where it depended on 2.0.1. If your application does not declare ssl itself, it picks up 3.0.0 through courier, and your own `use "ssl/net"` or `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
+
+courier's own API is unchanged — an HTTPS connection still takes an `SSLContext val`. What can break is your own ssl code. The one you are most likely to hit is the rename of the protocol-version primitives, which now spell their acronyms in full, because setting a minimum TLS version on the context you hand courier is ordinary practice:
+
+```pony
+// Before
+ctx.set_min_proto_version(Tls1u2Version())?
+
+// After
+ctx.set_min_proto_version(TLS1u2Version())?
+```
+
+All twelve protocol-version primitives were renamed the same way. ponylang/ssl 3.0.0 has other breaking changes too: constructing a `Digest`, `Digest.final`, and `HmacSha256` are now partial; `SSLContext.alpn_set_resolver` takes an `ALPNProtocolResolver val` where it took a `box`; `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`; and a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See ponylang/ssl's own 3.0.0 release notes for the full list.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Building and testing
 
 ```
+make ssl=4.0.x                      # build + run tests (OpenSSL 4.x)
 make ssl=3.0.x                      # build + run tests (OpenSSL 3.x)
 make ssl=1.1.x                      # OpenSSL 1.1.x
 make ssl=libressl                   # LibreSSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,21 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix a hang when closing a connection from a response callback ([PR #68](https://github.com/ponylang/courier/pull/68))
+- Fix a connection stalling under sustained write backpressure ([PR #68](https://github.com/ponylang/courier/pull/68))
+- Fix backpressure not stopping incoming data on an HTTPS connection ([PR #68](https://github.com/ponylang/courier/pull/68))
+- Fix yield_read() not taking effect on an HTTPS connection ([PR #68](https://github.com/ponylang/courier/pull/68))
+- Fix a hang when writing to a socket under load ([PR #68](https://github.com/ponylang/courier/pull/68))
+
 
 ### Added
 
 
+
 ### Changed
+
+- Require ponyc 0.67.0 or later ([PR #68](https://github.com/ponylang/courier/pull/68))
+- Move to ponylang/ssl 3.0.0 ([PR #68](https://github.com/ponylang/courier/pull/68))
 
 
 ## [0.4.0] - 2026-06-30

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs lint TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+          SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ courier is beta quality software that will change frequently. Expect breaking ch
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/courier.git --version 0.4.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.1"
+      "version": "0.17.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "3.0.0"
     }
   ]
 }

--- a/courier/_test.pony
+++ b/courier/_test.pony
@@ -205,3 +205,6 @@ actor \nodoc\ Main is TestList
     test(_TestURLErrorUserInfo)
     test(_TestURLValidPort65535)
     test(_TestURLQueryWithoutPath)
+
+    // Read loop tests
+    test(_TestYieldReadOrdering)

--- a/courier/_test_yield_read.pony
+++ b/courier/_test_yield_read.pony
@@ -1,0 +1,74 @@
+use lori = "lori"
+use "pony_test"
+
+class \nodoc\ iso _TestYieldReadOrdering is UnitTest
+  """
+  A `yield_read()` call from `on_body_chunk()` stops reading after the
+  delivery it was called from, and only that one.
+
+  Feeding the connection by hand is what makes the delivery boundary a fact
+  rather than an assumption: the returned `ReadAction` is the answer for the
+  delivery whose callback called `yield_read()`.
+  """
+  fun name(): String => "yield_read/stops_reading_after_its_delivery"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    h.dispose_when_done(_TestYieldReadOrderingClient(h))
+
+actor \nodoc\ _TestYieldReadOrderingClient is HTTPClientConnectionActor
+  var _http: HTTPClientConnection = HTTPClientConnection.none()
+  let _h: TestHelper
+  var _yielding: Bool = true
+  var _chunks: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+    // Nothing listens here. `HTTPClientConnection.create` builds the parser
+    // before it touches the network, and it queues `_finish_initialization`,
+    // so `drive` runs against a live parser whether or not the connect ever
+    // completes.
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _http =
+      HTTPClientConnection(
+        lori.TCPConnectAuth(h.env.root),
+        host,
+        "45999",
+        this,
+        ClientConnectionConfig)
+    drive()
+
+  fun ref _http_client_connection(): HTTPClientConnection => _http
+
+  be drive() =>
+    let response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"
+    let first = _http._on_received(response.clone().iso_array())
+    _h.assert_eq[USize](
+      1,
+      _chunks,
+      "the response body never reached on_body_chunk()")
+    _h.assert_is[lori.ReadAction](
+      lori.YieldReading,
+      first,
+      "yield_read() from on_body_chunk did not stop reading after the "
+        + "data it was called from")
+
+    _yielding = false
+    let second = _http._on_received(response.clone().iso_array())
+    _h.assert_is[lori.ReadAction](
+      lori.KeepReading,
+      second,
+      "reading stopped again on a delivery that never called yield_read()")
+
+    _h.complete(true)
+    _http.close()
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _chunks = _chunks + 1
+    if _yielding then
+      _http.yield_read()
+    end
+
+  fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+    // Expected — nothing is listening. The test drives the parser directly.
+    None

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -42,6 +42,7 @@ class HTTPClientConnection is
   var _state: _ConnectionState = _Active
   var _request_state: (_Idle | _AwaitingResponse) = _Idle
   var _parser: (_ResponseParser | None) = None
+  var _yield_read: Bool = false
 
   new none() =>
     """
@@ -167,19 +168,16 @@ class HTTPClientConnection is
 
   fun ref yield_read() =>
     """
-    Exit the read loop after the current callback, giving other actors a
-    chance to run. Reading resumes automatically on the next scheduler turn.
+    Stop reading once the parser finishes the data it is working on, giving
+    other actors a chance to run. Reading resumes on the next scheduler turn;
+    there is nothing to call to resume it.
 
     Intended for use inside `on_body_chunk()` to prevent a single large
-    response from starving other actors. Granularity is per-TCP-read, not
-    per-HTTP-chunk — one TCP read may contain multiple chunks, and they will
-    all be parsed before yielding. This is a one-shot flag; there is no
-    corresponding "unmute" needed.
-
-    No state guard is needed — if the connection is closed, the read loop
-    is not running and the flag is harmless.
+    response from starving other actors. Expect more callbacks after this
+    call: every chunk left in the data being parsed fires `on_body_chunk()`
+    before reading stops.
     """
-    _tcp_connection.yield_read()
+    _yield_read = true
 
   fun ref set_timer(duration: lori.TimerDuration)
     : (lori.TimerToken | lori.SetTimerError)
@@ -245,8 +243,17 @@ class HTTPClientConnection is
       r.on_connection_failure(courier_reason)
     end
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    // `yield_read()` runs from a callback the parser fires while handling
+    // this data, so reading the flag first would apply the yield one
+    // message late.
     _state.on_received(this, consume data)
+    if _yield_read then
+      _yield_read = false
+      lori.YieldReading
+    else
+      lori.KeepReading
+    end
 
   fun ref _on_closed() =>
     _state.on_closed(this)


### PR DESCRIPTION
lori 0.17.0 removes `TCPConnection.yield_read()` and has `_on_received` return a `ReadAction`. `HTTPClientConnection.yield_read()` stays for now, setting a flag that `_on_received` turns into `YieldReading`, so nothing changes for callers. Replacing it with a settable read buffer size is #72.

lori 0.17.0 also requires ponylang/ssl 3.0.0 and ponyc 0.67.0. If your application does not declare ssl itself, it picks up 3.0.0 through courier and your own `use "ssl/net"` code is built against it; if it does declare ssl, your declaration is the one that applies.
