### PR TITLE
Remove Stringable from error types

### DIFF
--- a/.release-notes/remove-stringable-from-parse-error-and-connection-failure-reason.md
+++ b/.release-notes/remove-stringable-from-parse-error-and-connection-failure-reason.md
@@ -1,0 +1,25 @@
+## Remove Stringable from error types
+
+`ParseError`, `ConnectionFailureReason`, and `URLParseError` primitives no longer implement `Stringable`. Users receive these through callbacks and can match on the concrete primitive to produce whatever string they want.
+
+Before:
+
+```pony
+fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+  _out.print("Connection failed: " + reason.string())
+```
+
+After:
+
+```pony
+fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+  let msg =
+    match \exhaustive\ reason
+    | ConnectionFailedDNS => "DNS resolution failed"
+    | ConnectionFailedTCP => "TCP connection failed"
+    | ConnectionFailedSSL => "SSL handshake failed"
+    | ConnectionFailedTimeout => "connection timed out"
+    | ConnectionFailedTimerError => "timer setup failed"
+    end
+  _out.print("Connection failed: " + msg)
+```

--- a/courier/_connection_failure_reason.pony
+++ b/courier/_connection_failure_reason.pony
@@ -1,31 +1,24 @@
-interface val _ConnectionFailureReason is Stringable
-
-primitive ConnectionFailedDNS is _ConnectionFailureReason
+primitive ConnectionFailedDNS
   """
   DNS resolution failed. No TCP connection was attempted.
   """
-  fun string(): String iso^ => "ConnectionFailedDNS".clone()
 
-primitive ConnectionFailedTCP is _ConnectionFailureReason
+primitive ConnectionFailedTCP
   """
   TCP connection failed after DNS resolution succeeded.
   """
-  fun string(): String iso^ => "ConnectionFailedTCP".clone()
 
-primitive ConnectionFailedSSL is _ConnectionFailureReason
+primitive ConnectionFailedSSL
   """
   SSL handshake failed after TCP connection succeeded.
   """
-  fun string(): String iso^ => "ConnectionFailedSSL".clone()
 
-primitive ConnectionFailedTimeout is _ConnectionFailureReason
+primitive ConnectionFailedTimeout
   """
   Connection attempt timed out before completing.
   """
-  fun string(): String iso^ => "ConnectionFailedTimeout".clone()
 
-primitive ConnectionFailedTimerError is _ConnectionFailureReason
+primitive ConnectionFailedTimerError
   """
   Connect timer ASIO event subscription failed.
   """
-  fun string(): String iso^ => "ConnectionFailedTimerError".clone()

--- a/courier/_parse_error.pony
+++ b/courier/_parse_error.pony
@@ -1,43 +1,34 @@
-interface val _ParseError is Stringable
-
-primitive TooLarge is _ParseError
+primitive TooLarge
   """
   Status line or headers exceed the configured size limit.
   """
-  fun string(): String iso^ => "TooLarge".clone()
 
-primitive InvalidStatusLine is _ParseError
+primitive InvalidStatusLine
   """
   Response status line is malformed.
   """
-  fun string(): String iso^ => "InvalidStatusLine".clone()
 
-primitive InvalidVersion is _ParseError
+primitive InvalidVersion
   """
   HTTP version is not HTTP/1.0 or HTTP/1.1.
   """
-  fun string(): String iso^ => "InvalidVersion".clone()
 
-primitive MalformedHeaders is _ParseError
+primitive MalformedHeaders
   """
   Header syntax is invalid (missing colon, obs-fold continuation line).
   """
-  fun string(): String iso^ => "MalformedHeaders".clone()
 
-primitive InvalidContentLength is _ParseError
+primitive InvalidContentLength
   """
   Content-Length is non-numeric, negative, or has conflicting values.
   """
-  fun string(): String iso^ => "InvalidContentLength".clone()
 
-primitive InvalidChunk is _ParseError
+primitive InvalidChunk
   """
   Chunked transfer encoding error: bad chunk size or missing CRLF.
   """
-  fun string(): String iso^ => "InvalidChunk".clone()
 
-primitive BodyTooLarge is _ParseError
+primitive BodyTooLarge
   """
   Response body exceeds the configured maximum body size.
   """
-  fun string(): String iso^ => "BodyTooLarge".clone()

--- a/courier/_test_url.pony
+++ b/courier/_test_url.pony
@@ -41,7 +41,7 @@ class \nodoc\ iso _PropertyURLRoundtrip is Property1[_ValidURLParts]
         ph.assert_true(parsed.query is None)
       end
     | let err: URLParseError =>
-      ph.fail("parse failed: " + err.string())
+      ph.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _PropertyURLDefaultPort is Property1[_ValidURLParts]
@@ -62,7 +62,7 @@ class \nodoc\ iso _PropertyURLDefaultPort is Property1[_ValidURLParts]
         if parsed.scheme is SchemeHTTP then "80" else "443" end
       ph.assert_eq[String val](expected, parsed.port)
     | let err: URLParseError =>
-      ph.fail("parse failed: " + err.string())
+      ph.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _PropertyURLRequestPathStartsWithSlash
@@ -82,7 +82,7 @@ class \nodoc\ iso _PropertyURLRequestPathStartsWithSlash
         rp.at("/"),
         "request_path should start with /: " + rp)
     | let err: URLParseError =>
-      ph.fail("parse failed: " + err.string())
+      ph.fail("unexpected parse error")
     end
 
 // ---------------------------------------------------------------------------
@@ -200,7 +200,7 @@ class \nodoc\ iso _TestURLFullComponents is UnitTest
       h.assert_eq[String val]("/api/v1?key=value", u.request_path())
       h.assert_true(u.is_ssl())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLMinimal is UnitTest
@@ -217,7 +217,7 @@ class \nodoc\ iso _TestURLMinimal is UnitTest
       h.assert_true(u.query is None)
       h.assert_false(u.is_ssl())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLDefaultPortHTTP is UnitTest
@@ -230,7 +230,7 @@ class \nodoc\ iso _TestURLDefaultPortHTTP is UnitTest
       h.assert_eq[String val]("80", u.port)
       h.assert_false(u.is_ssl())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLDefaultPortHTTPS is UnitTest
@@ -243,7 +243,7 @@ class \nodoc\ iso _TestURLDefaultPortHTTPS is UnitTest
       h.assert_eq[String val]("443", u.port)
       h.assert_true(u.is_ssl())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLMissingPathDefault is UnitTest
@@ -256,7 +256,7 @@ class \nodoc\ iso _TestURLMissingPathDefault is UnitTest
       h.assert_eq[String val]("/", u.path)
       h.assert_eq[String val]("/", u.request_path())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLFragmentDiscarded is UnitTest
@@ -269,7 +269,7 @@ class \nodoc\ iso _TestURLFragmentDiscarded is UnitTest
       h.assert_eq[String val]("/path", u.path)
       h.assert_true(u.query is None)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLIPv6Host is UnitTest
@@ -283,7 +283,7 @@ class \nodoc\ iso _TestURLIPv6Host is UnitTest
       h.assert_eq[String val]("8080", u.port)
       h.assert_eq[String val]("/path", u.path)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLIPv6DefaultPort is UnitTest
@@ -297,7 +297,7 @@ class \nodoc\ iso _TestURLIPv6DefaultPort is UnitTest
       h.assert_eq[String val]("80", u.port)
       h.assert_eq[String val]("/path", u.path)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLCaseInsensitiveScheme is UnitTest
@@ -309,13 +309,13 @@ class \nodoc\ iso _TestURLCaseInsensitiveScheme is UnitTest
     | let u: ParsedURL =>
       h.assert_true(u.scheme is SchemeHTTP)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
     match \exhaustive\ URL.parse("HtTpS://example.com/path")
     | let u: ParsedURL =>
       h.assert_true(u.scheme is SchemeHTTPS)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLEmptyPortDefault is UnitTest
@@ -327,7 +327,7 @@ class \nodoc\ iso _TestURLEmptyPortDefault is UnitTest
     | let u: ParsedURL =>
       h.assert_eq[String val]("80", u.port)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLErrorMissingScheme is UnitTest
@@ -423,7 +423,7 @@ class \nodoc\ iso _TestURLValidPort65535 is UnitTest
     | let u: ParsedURL =>
       h.assert_eq[String val]("65535", u.port)
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 
 class \nodoc\ iso _TestURLQueryWithoutPath is UnitTest
@@ -440,6 +440,6 @@ class \nodoc\ iso _TestURLQueryWithoutPath is UnitTest
       end
       h.assert_eq[String val]("/?key=value", u.request_path())
     | let err: URLParseError =>
-      h.fail("parse failed: " + err.string())
+      h.fail("unexpected parse error")
     end
 

--- a/courier/_url_parse_error.pony
+++ b/courier/_url_parse_error.pony
@@ -1,31 +1,24 @@
-interface val _URLParseError is Stringable
-
-primitive MissingScheme is _URLParseError
+primitive MissingScheme
   """
   URL has no `://` separator or the scheme portion is empty.
   """
-  fun string(): String iso^ => "MissingScheme".clone()
 
-primitive UnsupportedScheme is _URLParseError
+primitive UnsupportedScheme
   """
   URL scheme is not `http` or `https`.
   """
-  fun string(): String iso^ => "UnsupportedScheme".clone()
 
-primitive MissingHost is _URLParseError
+primitive MissingHost
   """
   URL has an empty host component.
   """
-  fun string(): String iso^ => "MissingHost".clone()
 
-primitive InvalidPort is _URLParseError
+primitive InvalidPort
   """
   Port is non-numeric, zero, or exceeds 65535.
   """
-  fun string(): String iso^ => "InvalidPort".clone()
 
-primitive UserInfoNotSupported is _URLParseError
+primitive UserInfoNotSupported
   """
   URL contains userinfo (`user@` or `user:pass@`), which is not supported.
   """
-  fun string(): String iso^ => "UserInfoNotSupported".clone()

--- a/examples/response-timeout/main.pony
+++ b/examples/response-timeout/main.pony
@@ -72,7 +72,15 @@ actor ResponseTimeoutClient is HTTPClientConnectionActor
     end
 
   fun ref on_connection_failure(reason: ConnectionFailureReason) =>
-    _out.print("Connection failed: " + reason.string())
+    let msg =
+      match \exhaustive\ reason
+      | ConnectionFailedDNS => "DNS resolution failed"
+      | ConnectionFailedTCP => "TCP connection failed"
+      | ConnectionFailedSSL => "SSL handshake failed"
+      | ConnectionFailedTimeout => "connection timed out"
+      | ConnectionFailedTimerError => "timer setup failed"
+      end
+    _out.print("Connection failed: " + msg)
 
   fun ref on_response(response: Response val) =>
     _out.print("< " + response.status.string() + " " + response.reason)

--- a/examples/url-parsing/main.pony
+++ b/examples/url-parsing/main.pony
@@ -16,5 +16,13 @@ actor Main
       env.out.print("  request_path: " + url.request_path())
       env.out.print("  is_ssl: " + url.is_ssl().string())
     | let err: URLParseError =>
-      env.out.print("URL parse error: " + err.string())
+      let msg =
+        match \exhaustive\ err
+        | MissingScheme => "missing scheme"
+        | UnsupportedScheme => "unsupported scheme"
+        | MissingHost => "missing host"
+        | InvalidPort => "invalid port"
+        | UserInfoNotSupported => "userinfo not supported"
+        end
+      env.out.print("URL parse error: " + msg)
     end


### PR DESCRIPTION
`ParseError`, `ConnectionFailureReason`, and `URLParseError` primitives no longer implement `Stringable`. Users receive these through callbacks and can match on the concrete primitive to produce whatever string they want — the library doesn't need to dictate the representation. Same pattern as `RedirectError`.

The private marker interfaces (`_ParseError`, `_ConnectionFailureReason`, `_URLParseError`) are also removed since they'd be empty after dropping `Stringable`; the public union type aliases already serve as the grouping type.

The `response-timeout` and `url-parsing` examples were the only code in the repo calling `.string()` on these types — updated to use exhaustive matches.

Closes #79
