### PR TITLE
Fix on_closed firing twice when closing a backed-up connection

### DIFF
--- a/.release-notes/fix-double-on-closed.md
+++ b/.release-notes/fix-double-on-closed.md
@@ -1,0 +1,3 @@
+## Fix on_closed firing twice when closing a backed-up connection
+
+Closing a connection while the socket had backpressure applied delivered `on_closed()` to the application twice. A single `on_closed()` is now delivered regardless of socket state at close time.

--- a/courier/http_client_connection.pony
+++ b/courier/http_client_connection.pony
@@ -401,6 +401,6 @@ class HTTPClientConnection is
       match _lifecycle_event_receiver
       | let r: HTTPClientLifecycleEventReceiver ref => r.on_closed()
       end
-      _tcp_connection.close()
       _state = _Closed
+      _tcp_connection.close()
     end


### PR DESCRIPTION
Closing a connection while the socket had backpressure applied delivered `on_closed()` to the application twice — lori's `close()` hard-closes synchronously on a muted socket, re-entering `_on_closed` while `_state` was still `_Active`.

Setting `_state = _Closed` before calling `_tcp_connection.close()` makes the re-entrant `_on_closed` hit `_Closed.on_closed` (a no-op).
